### PR TITLE
feat(bin/poll): CLI for one-shot polling and writing to files

### DIFF
--- a/bin/poll.js
+++ b/bin/poll.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+const {
+  backends,
+  customResourceManifest,
+  kubeClient,
+  logger
+} = require('../config')
+
+async function main () {
+  const destinationPath = process.env['DESTINATION_PATH']
+  const externalSecretName = process.env['EXTERNAL_SECRET_NAME']
+  const namespace = process.env['EXTERNAL_SECRET_NAMESPACE']
+
+  logger.info('loading kube specs')
+  await kubeClient.loadSpec()
+  kubeClient.addCustomResourceDefinition(customResourceManifest)
+  logger.info('successfully loaded kube specs')
+
+  const res = await kubeClient
+    .apis[customResourceManifest.spec.group].v1
+    .namespaces(namespace)[customResourceManifest.spec.names.plural](externalSecretName)
+    .get()
+  if (res.statusCode !== 200) {
+    throw new Error(`Failed to fetch ExternalSecret: ${JSON.stringify(res, null, 2)}`)
+  }
+
+  const externalSecret = res.body
+  const { secretDescriptor } = externalSecret
+  const backend = backends[secretDescriptor.backendType]
+  if (!backend) {
+    throw new Error(`Unknown backend type: ${secretDescriptor.backendType}`)
+  }
+
+  const data = await backend.getSecretManifestData({ secretDescriptor })
+  Object.entries(data).forEach(([filename, encodedContents]) => {
+    const filenamePath = path.join(destinationPath, filename)
+    const contents = Buffer.from(encodedContents, 'base64')
+    fs.writeFileSync(filenamePath, contents) // eslint-disable-line security/detect-non-literal-fs-filename
+  })
+}
+
+main()
+  .catch(err => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/examples/init-container-example.yml
+++ b/examples/init-container-example.yml
@@ -1,0 +1,55 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: external-secrets-reader
+rules:
+- apiGroups: ["kubernetes-client.io"]
+  resources: ["externalsecrets"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: external-secrets-reader
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: external-secrets-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: init-container-example
+  labels:
+    app: init-container-example
+spec:
+  containers:
+  - name: init-container-example
+    image: busybox
+    command: ['sh', '-c', 'ls /external-secrets && sleep 3600']
+    volumeMounts:
+    - name: demo-service
+      mountPath: "/external-secrets"
+  initContainers:
+  - name: external-secret-init-0
+    image: "godaddy/kubernetes-external-secrets:test"
+    command: ['npm', 'run', 'poll']
+    env:
+      - name: AWS_REGION
+        value: us-west-2
+      - name: DESTINATION_PATH
+        value: "/external-secret-0"
+      - name: EXTERNAL_SECRET_NAME
+        value: demo-service
+      - name: EXTERNAL_SECRET_NAMESPACE
+        value: demo-service
+    volumeMounts:
+    - name: demo-service
+      mountPath: "/external-secret-0"
+  volumes:
+  - name: demo-service
+    emptyDir:
+      medium: "Memory"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "coverage": "nyc ./node_modules/mocha/bin/_mocha --recursive lib",
     "lint": "eslint --fix --ignore-pattern /coverage/ ./",
+    "poll": "./bin/poll.js",
     "release": "standard-version --tag-prefix='' && ./release.sh",
     "start": "./bin/daemon.js",
     "nodemon": "nodemon ./bin/daemon.js",


### PR DESCRIPTION
Inlcude an example of using `npm run poll` as an Init Container. Part of the
design proposed here:

https://github.com/godaddy/kubernetes-external-secrets/issues/46