### PR TITLE
feature/parameterstorebypath

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ coverage
 Dockerfile
 node_modules
 release.sh
+

--- a/config/index.js
+++ b/config/index.js
@@ -13,6 +13,7 @@ const envConfig = require('./environment')
 const CustomResourceManager = require('../lib/custom-resource-manager')
 const SecretsManagerBackend = require('../lib/backends/secrets-manager-backend')
 const SystemManagerBackend = require('../lib/backends/system-manager-backend')
+const SystemManagerBackendbyPath = require('../lib/backends/system-manager-backend-bypath')
 const VaultBackend = require('../lib/backends/vault-backend')
 
 // Get document, or throw exception on error
@@ -46,12 +47,18 @@ const systemManagerBackend = new SystemManagerBackend({
   assumeRole: awsConfig.assumeRole,
   logger
 })
+const systemManagerBackendbyPath = new SystemManagerBackendbyPath({
+  clientFactory: awsConfig.systemManagerFactory,
+  assumeRole: awsConfig.assumeRole,
+  logger
+})
 const vaultClient = vault({ apiVersion: 'v1', endpoint: envConfig.vaultEndpoint })
 const vaultBackend = new VaultBackend({ client: vaultClient, logger })
 const backends = {
   // when adding a new backend, make sure to change the CRD property too
   secretsManager: secretsManagerBackend,
   systemManager: systemManagerBackend,
+  systemManagerbyPath: systemManagerBackendbyPath,
   vault: vaultBackend
 }
 

--- a/examples/ssm-example-by-path.yaml
+++ b/examples/ssm-example-by-path.yaml
@@ -1,0 +1,10 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: ssm-example-by-path
+spec:
+  backendType: systemManagerbyPath
+  # optional: specify role to assume when retrieving the data
+  roleArn: arn:aws:iam::123456789012:role/test-role
+  dataFromPath:
+    - /foo/name1

--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -17,7 +17,6 @@ class KVBackend extends AbstractBackend {
    * Fetch Kubernetes secret property values.
    * @param {Object[]} data - Kubernetes secret properties.
    * @param {string} data[].key - Secret key in the backend.
-   * @param {string} data[].path - Path from where to fetch keys in the backend.
    * @param {string} data[].name - Kubernetes Secret property name.
    * @param {string} data[].property - If the backend secret is an
    *   object, this is the property name of the value to use.
@@ -26,8 +25,8 @@ class KVBackend extends AbstractBackend {
    */
   _fetchDataValues({ data, specOptions }) {
     return Promise.all(data.map(async dataItem => {
-      const { name, property = null, path, key, ...keyOptions } = dataItem
-      const plainOrObjValue = await this._get({ path, specOptions })
+      const { name, property = null, key, ...keyOptions } = dataItem
+      const plainOrObjValue = await this._get({ key, specOptions })
       const shouldParseValue = 'property' in dataItem
 
       let value = plainOrObjValue
@@ -48,18 +47,14 @@ class KVBackend extends AbstractBackend {
         value = parsedValue[property]
       }
 
-      if (path) { // MORE THAN ONE PARAMETER
-        return value
-      } else {
-        return { [name]: value }
-      }
+      return { [name]: value }
 
     }))
   }
 
   /**
    * Fetch Kubernetes secret property values.
-   * @param {string[]} dataFrom - Array of secret keys in the backend
+   * @param {Object[]} dataFrom - Array of secret keys in the backend
    * @param {string} specOptions - Options set on spec level that might be interesting for the backend
    * @returns {Promise} Promise object representing secret property values.
    */
@@ -73,6 +68,22 @@ class KVBackend extends AbstractBackend {
         this._logger.warn(`Failed to JSON.parse value for '${key}',` +
           ' please verify that your secret value is correctly formatted as JSON.')
       }
+    }))
+  }
+
+  /**
+   * Fetch Kubernetes secret property values.
+   * @param {Object[]} dataFromPath - Secret key in the backend.
+   * @param {string} specOptions - Options set on spec level that might be interesting for the backend
+   * @returns {Promise} Promise object representing secret property values.
+   */
+  _fetchDataFromPath({ dataFromPath, specOptions }) {
+    return Promise.all(dataFromPath.map(async path => {
+      const { fromPath, ...keyOptions } = path
+      const returnValues = await this._get({ path, specOptions })
+
+      return returnValues
+
     }))
   }
 
@@ -98,35 +109,27 @@ class KVBackend extends AbstractBackend {
       properties = [],
       data = properties,
       dataFrom = [],
+      dataFromPath = [],
       ...specOptions
     }
   }) {
-    const [dataFromValues, dataValues] = await Promise.all([
+    const [dataFromValues, dataValues, fromPath] = await Promise.all([
       this._fetchDataFromValues({ dataFrom, specOptions }),
-      this._fetchDataValues({ data, specOptions })
+      this._fetchDataValues({ data, specOptions }),
+      this._fetchDataFromPath({ dataFromPath, specOptions }),
     ])
 
-    const plainValues = dataFromValues.concat(dataValues)
+    const plainValues = dataFromValues.concat(dataValues).concat(fromPath)
       .reduce((acc, parsedValue) => ({
         ...acc,
         ...parsedValue
       }), {})
 
-    var encodedEntries = []
-
-    if (dataValues[0]) { // MORE THAN ONE PARAMETER IS COMING
-      encodedEntries = Object.entries(dataValues[0])
-        .map(([key]) => [
-          require('path').basename(dataValues[0][key].key),
-          (Buffer.from(`${dataValues[0][key].value}`, 'utf8')).toString('base64')
-        ]);
-    } else {
-      encodedEntries = Object.entries(dataValues)
-        .map(([name, value]) => [
-          name,
-          (Buffer.from(`${value}`, 'utf8')).toString('base64')
-        ])
-    }
+    const encodedEntries = [] = Object.entries(plainValues)
+      .map(([name, value]) => [
+        name,
+        (Buffer.from(`${value}`, 'utf8')).toString('base64')
+      ])
 
     return Object.fromEntries(encodedEntries)
   }

--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -26,7 +26,7 @@ class KVBackend extends AbstractBackend {
   _fetchDataValues({ data, specOptions }) {
     return Promise.all(data.map(async dataItem => {
       const { name, property = null, key, ...keyOptions } = dataItem
-      const plainOrObjValue = await this._get({ key, specOptions })
+      const plainOrObjValue = await this._get({ key, keyOptions, specOptions })
       const shouldParseValue = 'property' in dataItem
 
       let value = plainOrObjValue
@@ -54,7 +54,7 @@ class KVBackend extends AbstractBackend {
 
   /**
    * Fetch Kubernetes secret property values.
-   * @param {Object[]} dataFrom - Array of secret keys in the backend
+   * @param {string[]} dataFrom - Array of secret keys in the backend
    * @param {string} specOptions - Options set on spec level that might be interesting for the backend
    * @returns {Promise} Promise object representing secret property values.
    */
@@ -73,7 +73,7 @@ class KVBackend extends AbstractBackend {
 
   /**
    * Fetch Kubernetes secret property values.
-   * @param {Object[]} dataFromPath - Secret key in the backend.
+   * @param {string[]} dataFromPath - Secret key in the backend.
    * @param {string} specOptions - Options set on spec level that might be interesting for the backend
    * @returns {Promise} Promise object representing secret property values.
    */

--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -8,7 +8,7 @@ class KVBackend extends AbstractBackend {
    * Create a Key Value backend.
    * @param {Object} logger - Logger for logging stuff.
    */
-  constructor ({ logger }) {
+  constructor({ logger }) {
     super()
     this._logger = logger
   }
@@ -17,16 +17,17 @@ class KVBackend extends AbstractBackend {
    * Fetch Kubernetes secret property values.
    * @param {Object[]} data - Kubernetes secret properties.
    * @param {string} data[].key - Secret key in the backend.
+   * @param {string} data[].path - Path from where to fetch keys in the backend.
    * @param {string} data[].name - Kubernetes Secret property name.
    * @param {string} data[].property - If the backend secret is an
    *   object, this is the property name of the value to use.
    * @param {Object} specOptions - Options set on spec level.
    * @returns {Promise} Promise object representing secret property values.
    */
-  _fetchDataValues ({ data, specOptions }) {
+  _fetchDataValues({ data, specOptions }) {
     return Promise.all(data.map(async dataItem => {
-      const { name, property = null, key, ...keyOptions } = dataItem
-      const plainOrObjValue = await this._get({ key, keyOptions, specOptions })
+      const { property = null, path } = dataItem
+      const plainOrObjValue = await this._get({ path, specOptions })
       const shouldParseValue = 'property' in dataItem
 
       let value = plainOrObjValue
@@ -36,19 +37,23 @@ class KVBackend extends AbstractBackend {
           parsedValue = JSON.parse(value)
         } catch (err) {
           this._logger.warn(`Failed to JSON.parse value for '${key}',` +
-           ' please verify that your secret value is correctly formatted as JSON.' +
-           ` To use plain text secret remove the 'property: ${property}'`)
+            ' please verify that your secret value is correctly formatted as JSON.' +
+            ` To use plain text secret remove the 'property: ${property}'`)
           return
         }
 
         if (!(property in parsedValue)) {
           throw new Error(`Could not find property ${property} in ${key}`)
         }
-
         value = parsedValue[property]
       }
 
-      return { [name]: value }
+      // for (var key in value) {
+      //   console.log(value[key]);
+      // }
+
+
+      return value
     }))
   }
 
@@ -58,7 +63,7 @@ class KVBackend extends AbstractBackend {
    * @param {string} specOptions - Options set on spec level that might be interesting for the backend
    * @returns {Promise} Promise object representing secret property values.
    */
-  _fetchDataFromValues ({ dataFrom, specOptions }) {
+  _fetchDataFromValues({ dataFrom, specOptions }) {
     return Promise.all(dataFrom.map(async key => {
       const value = await this._get({ key, specOptions, keyOptions: {} })
 
@@ -66,7 +71,7 @@ class KVBackend extends AbstractBackend {
         return JSON.parse(value)
       } catch (err) {
         this._logger.warn(`Failed to JSON.parse value for '${key}',` +
-           ' please verify that your secret value is correctly formatted as JSON.')
+          ' please verify that your secret value is correctly formatted as JSON.')
       }
     }))
   }
@@ -78,7 +83,7 @@ class KVBackend extends AbstractBackend {
    * @param {string} specOptions - Options for this external secret, eg role
    * @returns {Promise} Promise object representing secret property values.
    */
-  _get ({ key, keyOptions, specOptions }) {
+  _get({ key, keyOptions, specOptions }) {
     throw new Error('_get not implemented')
   }
 
@@ -87,7 +92,7 @@ class KVBackend extends AbstractBackend {
    * @param {ExternalSecretSpec} spec - Kubernetes ExternalSecret spec.
    * @returns {Promise} Promise object representing Kubernetes secret manifest data.
    */
-  async getSecretManifestData ({
+  async getSecretManifestData({
     spec: {
       // Use properties to be backwards compatible.
       properties = [],
@@ -96,22 +101,38 @@ class KVBackend extends AbstractBackend {
       ...specOptions
     }
   }) {
-    const [dataFromValues, dataValues] = await Promise.all([
-      this._fetchDataFromValues({ dataFrom, specOptions }),
+    const [dataValues] = await Promise.all([
       this._fetchDataValues({ data, specOptions })
     ])
 
-    const plainValues = dataFromValues.concat(dataValues)
-      .reduce((acc, parsedValue) => ({
-        ...acc,
-        ...parsedValue
-      }), {})
+    // const plainValues = dataFromValues.concat(dataValues)
+    //   .reduce((acc, parsedValue) => ({
+    //     ...acc,
+    //     ...parsedValue
+    //   }), {})
 
-    const encodedEntries = Object.entries(plainValues)
-      .map(([name, plainValue]) => [
-        name,
-        (Buffer.from(`${plainValue}`, 'utf8')).toString('base64')
-      ])
+    //this._logger.info(`VALUES ARE: ${plainValues}`)
+
+
+    //const encodedEntries = ""
+    // Object.entries(dataValues)
+    //   .map(([name, value]) => [
+    //     name,
+    //     (Buffer.from(`${value}`, 'utf8')).toString('base64')
+    //   ])
+    //console.log(dataValues[0][0].key)
+
+    const encodedEntries = Object.entries(dataValues[0])
+      .map(([key]) => [
+        require('path').basename(dataValues[0][key].key),
+        (Buffer.from(`${dataValues[0][key].value}`, 'utf8')).toString('base64')
+      ]);
+
+    Object.entries(Object.entries(dataValues[0])
+      .map(([key]) => console.log(
+        require('path').basename(dataValues[0][key].key),
+        (Buffer.from(`${dataValues[0][key].value}`, 'utf8')).toString('base64')
+      )));
 
     return Object.fromEntries(encodedEntries)
   }

--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -26,7 +26,7 @@ class KVBackend extends AbstractBackend {
    */
   _fetchDataValues({ data, specOptions }) {
     return Promise.all(data.map(async dataItem => {
-      const { property = null, path } = dataItem
+      const { name, property = null, path, key, ...keyOptions } = dataItem
       const plainOrObjValue = await this._get({ path, specOptions })
       const shouldParseValue = 'property' in dataItem
 
@@ -48,12 +48,12 @@ class KVBackend extends AbstractBackend {
         value = parsedValue[property]
       }
 
-      // for (var key in value) {
-      //   console.log(value[key]);
-      // }
+      if (path) { // MORE THAN ONE PARAMETER
+        return value
+      } else {
+        return { [name]: value }
+      }
 
-
-      return value
     }))
   }
 
@@ -101,38 +101,32 @@ class KVBackend extends AbstractBackend {
       ...specOptions
     }
   }) {
-    const [dataValues] = await Promise.all([
+    const [dataFromValues, dataValues] = await Promise.all([
+      this._fetchDataFromValues({ dataFrom, specOptions }),
       this._fetchDataValues({ data, specOptions })
     ])
 
-    // const plainValues = dataFromValues.concat(dataValues)
-    //   .reduce((acc, parsedValue) => ({
-    //     ...acc,
-    //     ...parsedValue
-    //   }), {})
+    const plainValues = dataFromValues.concat(dataValues)
+      .reduce((acc, parsedValue) => ({
+        ...acc,
+        ...parsedValue
+      }), {})
 
-    //this._logger.info(`VALUES ARE: ${plainValues}`)
+    var encodedEntries = []
 
-
-    //const encodedEntries = ""
-    // Object.entries(dataValues)
-    //   .map(([name, value]) => [
-    //     name,
-    //     (Buffer.from(`${value}`, 'utf8')).toString('base64')
-    //   ])
-    //console.log(dataValues[0][0].key)
-
-    const encodedEntries = Object.entries(dataValues[0])
-      .map(([key]) => [
-        require('path').basename(dataValues[0][key].key),
-        (Buffer.from(`${dataValues[0][key].value}`, 'utf8')).toString('base64')
-      ]);
-
-    Object.entries(Object.entries(dataValues[0])
-      .map(([key]) => console.log(
-        require('path').basename(dataValues[0][key].key),
-        (Buffer.from(`${dataValues[0][key].value}`, 'utf8')).toString('base64')
-      )));
+    if (dataValues[0]) { // MORE THAN ONE PARAMETER IS COMING
+      encodedEntries = Object.entries(dataValues[0])
+        .map(([key]) => [
+          require('path').basename(dataValues[0][key].key),
+          (Buffer.from(`${dataValues[0][key].value}`, 'utf8')).toString('base64')
+        ]);
+    } else {
+      encodedEntries = Object.entries(dataValues)
+        .map(([name, value]) => [
+          name,
+          (Buffer.from(`${value}`, 'utf8')).toString('base64')
+        ])
+    }
 
     return Object.fromEntries(encodedEntries)
   }

--- a/lib/backends/system-manager-backend-bypath.js
+++ b/lib/backends/system-manager-backend-bypath.js
@@ -17,6 +17,7 @@ class SystemManagerBackendbyPath extends KVBackend {
     this._assumeRole = assumeRole
   }
 
+
   /**
    * Get secret property value from System Manager.
    * @param {string} path - Key used to store secret property value in System Manager.
@@ -24,9 +25,13 @@ class SystemManagerBackendbyPath extends KVBackend {
    * @param {string} specOptions.roleArn - IAM role arn to assume
    * @returns {Promise} Promise object representing secret property value.
    */
-  async _get({ path, specOptions: { roleArn } }) {
+  async _get({ path = '', specOptions: { roleArn } }) {
 
-    var parameters = []
+    if (path == '') {
+      console.log('No path defined')
+      return // IN CASE ITS NOT A PATH SECRET EXIT
+    }
+
 
     this._logger.info(`fetching all secrets in path ${path} with role: ${roleArn || 'pods role'}`)
 
@@ -70,19 +75,19 @@ class SystemManagerBackendbyPath extends KVBackend {
     }
 
     // use it
+    var parameters = {}
+
     const ssmData = await getAllParameters();
 
     for (var ssmRecord in ssmData) {
 
-      var paramName = ssmData[ssmRecord].Name
+      var paramName = require('path').basename(ssmData[ssmRecord].Name)
       var paramValue = ssmData[ssmRecord].Value
 
-      parameters.push({
-        key: paramName,
-        value: paramValue
-      })
-    }
+      parameters[paramName] = paramValue
 
+    }
+    //console.log(parameters)
     return parameters
   }
 }

--- a/lib/backends/system-manager-backend-bypath.js
+++ b/lib/backends/system-manager-backend-bypath.js
@@ -1,0 +1,161 @@
+'use strict'
+
+const KVBackend = require('./kv-backend')
+
+/** System Manager backend class. */
+class SystemManagerBackendbyPath extends KVBackend {
+
+  /**
+   * Create System Manager backend.
+   * @param {Object} client - Client for interacting with System Manager.
+   * @param {Object} logger - Logger for logging stuff.
+   */
+  constructor({ clientFactory, assumeRole, logger }) {
+    super({ logger })
+    this._client = clientFactory()
+    this._clientFactory = clientFactory
+    this._assumeRole = assumeRole
+  }
+
+  /**
+   * Get secret property value from System Manager.
+   * @param {string} path - Key used to store secret property value in System Manager.
+   * @param {object} specOptions - Options for this external secret, eg role
+   * @param {string} specOptions.roleArn - IAM role arn to assume
+   * @returns {Promise} Promise object representing secret property value.
+   */
+  async _get({ path, specOptions: { roleArn } }) {
+
+    var parameters = []
+
+    this._logger.info(`fetching all secrets in path ${path} with role: ${roleArn || 'pods role'}`)
+
+    let client = this._client
+    if (roleArn) {
+      const res = await this._assumeRole({
+        RoleArn: roleArn,
+        RoleSessionName: 'k8s-external-secrets'
+      })
+      client = this._clientFactory({
+        accessKeyId: res.Credentials.AccessKeyId,
+        secretAccessKey: res.Credentials.SecretAccessKey,
+        sessionToken: res.Credentials.SessionToken
+      })
+    }
+
+    // const data = await client
+    //   .getParametersByPath({
+    //     Path: path,
+    //     WithDecryption: true,
+    //     Recursive: false
+    //   })
+    //   .promise()
+
+
+
+
+    // Adapted from https://advancedweb.hu/2019/07/30/async_gen_paginate_aws/
+    const getAllParameters = async () => {
+      const EMPTY = Symbol("empty");
+
+      const res = [];
+      for await (const lf of (async function* () {
+        let NextToken = EMPTY;
+        while (NextToken || NextToken === EMPTY) {
+          console.log(`Fetching paginated parameters for ${path} ...`)
+          const parameters = await client.getParametersByPath({
+            Path: path,
+            WithDecryption: true,
+            Recursive: false,
+            NextToken: NextToken !== EMPTY ? NextToken : undefined
+          }).promise();
+          yield* parameters.Parameters;
+          NextToken = parameters.NextToken;
+        }
+      })()) {
+        res.push(lf);
+      }
+
+      return res;
+    }
+
+    // use it
+    const ssmData = await getAllParameters();
+
+    // client.getParametersByPath({ Path: path, Recursive: true, WithDecryption: true }, (err, data) => {
+    //   if (err) throw err, reject()
+    //   saveParameter(data)
+    // })
+
+
+
+    // async function handleResponse(response) {
+    //   new Promise((resolve, reject) => {
+    //     if (response.Parameters.length === 0) reject()
+    //     response.Parameters.forEach(saveParameter)
+    //     if (!response.NextToken) {
+    //       console.log('======================================== FINISHED ========================================')
+    //       resolve()
+    //     }
+    //     await getParametersByPath(response.NextToken, handleResponse)
+    //   })
+    // }
+
+    // async function getParametersByPath(nextToken, callback) {
+    //   new Promise((resolve, reject) => {
+    //     const params = { Path: path, Recursive: true, WithDecryption: true }
+
+    //     if (nextToken) params['NextToken'] = nextToken
+
+    //     client.getParametersByPath(params, (err, data) => {
+    //       if (err) throw err, reject()
+    //       callback(data)
+    //     })
+    //   })
+    // }
+
+    // function saveParameter(parameter) {
+    //   const envName = require('path').basename(parameter.Name)
+    //   console.log(`${envName}="${parameter.Value}"`)
+    //   parameters.push({
+    //     key: envName,
+    //     value: parameter.Value
+    //   })
+    // }
+
+    //const data = await getParametersByPath(null, handleResponse)
+
+    //console.log(data)
+    //console.log(data['Parameters'])
+    // data.map(param => {
+    //   console.log(param.Name + ": " + param.Value)
+    // });
+    //this._logger.info(`DATA: ${returnedparameters}`)
+    //this._logger.info(`DATA: ${JSON.stringify(data)}`)
+
+    // parsedJson = JSON.parse(data)
+    // var parameters = []
+
+    for (var ssmRecord in ssmData) {
+
+      var paramName = data[ssmRecord].Name
+      var paramValue = data[ssmRecord].Value
+
+      //console.log(paramName + ": " + paramValue);
+
+      parameters.push({
+        key: paramName,
+        value: paramValue
+      })
+    }
+
+    //console.log(parameters)
+
+
+
+    //var parameters = ""
+    return parameters
+  }
+}
+
+module.exports = SystemManagerBackendbyPath

--- a/lib/backends/system-manager-backend-bypath.js
+++ b/lib/backends/system-manager-backend-bypath.js
@@ -27,12 +27,6 @@ class SystemManagerBackendbyPath extends KVBackend {
    */
   async _get({ path = '', specOptions: { roleArn } }) {
 
-    if (path == '') {
-      console.log('No path defined')
-      return // IN CASE ITS NOT A PATH SECRET EXIT
-    }
-
-
     this._logger.info(`fetching all secrets in path ${path} with role: ${roleArn || 'pods role'}`)
 
     let client = this._client

--- a/lib/backends/system-manager-backend-bypath.js
+++ b/lib/backends/system-manager-backend-bypath.js
@@ -43,17 +43,6 @@ class SystemManagerBackendbyPath extends KVBackend {
       })
     }
 
-    // const data = await client
-    //   .getParametersByPath({
-    //     Path: path,
-    //     WithDecryption: true,
-    //     Recursive: false
-    //   })
-    //   .promise()
-
-
-
-
     // Adapted from https://advancedweb.hu/2019/07/30/async_gen_paginate_aws/
     const getAllParameters = async () => {
       const EMPTY = Symbol("empty");
@@ -61,13 +50,14 @@ class SystemManagerBackendbyPath extends KVBackend {
       const res = [];
       for await (const lf of (async function* () {
         let NextToken = EMPTY;
-        while (NextToken || NextToken === EMPTY) {
+        while (NextToken && NextToken === EMPTY) {
+          //while (NextToken || NextToken === EMPTY) {
           console.log(`Fetching paginated parameters for ${path} ...`)
           const parameters = await client.getParametersByPath({
             Path: path,
             WithDecryption: true,
             Recursive: false,
-            NextToken: NextToken !== EMPTY ? NextToken : undefined
+            //NextToken: NextToken !== EMPTY ? NextToken : undefined
           }).promise();
           yield* parameters.Parameters;
           NextToken = parameters.NextToken;
@@ -82,66 +72,10 @@ class SystemManagerBackendbyPath extends KVBackend {
     // use it
     const ssmData = await getAllParameters();
 
-    // client.getParametersByPath({ Path: path, Recursive: true, WithDecryption: true }, (err, data) => {
-    //   if (err) throw err, reject()
-    //   saveParameter(data)
-    // })
-
-
-
-    // async function handleResponse(response) {
-    //   new Promise((resolve, reject) => {
-    //     if (response.Parameters.length === 0) reject()
-    //     response.Parameters.forEach(saveParameter)
-    //     if (!response.NextToken) {
-    //       console.log('======================================== FINISHED ========================================')
-    //       resolve()
-    //     }
-    //     await getParametersByPath(response.NextToken, handleResponse)
-    //   })
-    // }
-
-    // async function getParametersByPath(nextToken, callback) {
-    //   new Promise((resolve, reject) => {
-    //     const params = { Path: path, Recursive: true, WithDecryption: true }
-
-    //     if (nextToken) params['NextToken'] = nextToken
-
-    //     client.getParametersByPath(params, (err, data) => {
-    //       if (err) throw err, reject()
-    //       callback(data)
-    //     })
-    //   })
-    // }
-
-    // function saveParameter(parameter) {
-    //   const envName = require('path').basename(parameter.Name)
-    //   console.log(`${envName}="${parameter.Value}"`)
-    //   parameters.push({
-    //     key: envName,
-    //     value: parameter.Value
-    //   })
-    // }
-
-    //const data = await getParametersByPath(null, handleResponse)
-
-    //console.log(data)
-    //console.log(data['Parameters'])
-    // data.map(param => {
-    //   console.log(param.Name + ": " + param.Value)
-    // });
-    //this._logger.info(`DATA: ${returnedparameters}`)
-    //this._logger.info(`DATA: ${JSON.stringify(data)}`)
-
-    // parsedJson = JSON.parse(data)
-    // var parameters = []
-
     for (var ssmRecord in ssmData) {
 
-      var paramName = data[ssmRecord].Name
-      var paramValue = data[ssmRecord].Value
-
-      //console.log(paramName + ": " + paramValue);
+      var paramName = ssmData[ssmRecord].Name
+      var paramValue = ssmData[ssmRecord].Value
 
       parameters.push({
         key: paramName,
@@ -149,11 +83,6 @@ class SystemManagerBackendbyPath extends KVBackend {
       })
     }
 
-    //console.log(parameters)
-
-
-
-    //var parameters = ""
     return parameters
   }
 }

--- a/lib/backends/system-manager-backend-bypath.js
+++ b/lib/backends/system-manager-backend-bypath.js
@@ -49,14 +49,13 @@ class SystemManagerBackendbyPath extends KVBackend {
       const res = [];
       for await (const lf of (async function* () {
         let NextToken = EMPTY;
-        while (NextToken && NextToken === EMPTY) {
-          //while (NextToken || NextToken === EMPTY) {
+        while (NextToken || NextToken === EMPTY) {
           console.log(`Fetching paginated parameters for ${path} ...`)
           const parameters = await client.getParametersByPath({
             Path: path,
             WithDecryption: true,
             Recursive: false,
-            //NextToken: NextToken !== EMPTY ? NextToken : undefined
+            NextToken: NextToken !== EMPTY ? NextToken : undefined
           }).promise();
           yield* parameters.Parameters;
           NextToken = parameters.NextToken;

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -10,7 +10,6 @@ const merge = require('lodash.merge')
  * @param {string} name - Kubernetes secret name.
  * @param {Object[]} properties - Kubernetes secret properties.
  * @param {string} properties[].key - Secret key in the backend.
- * @param {string} properties[].path - Path from where to fetch keys in the backend.
  * @param {string} properties[].name - Kubernetes Secret property name.
  * @param {string} properties[].property - If the backend secret is an
  *   object, this is the property name of the value to use.

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -10,6 +10,7 @@ const merge = require('lodash.merge')
  * @param {string} name - Kubernetes secret name.
  * @param {Object[]} properties - Kubernetes secret properties.
  * @param {string} properties[].key - Secret key in the backend.
+ * @param {string} properties[].path - Path from where to fetch keys in the backend.
  * @param {string} properties[].name - Kubernetes Secret property name.
  * @param {string} properties[].property - If the backend secret is an
  *   object, this is the property name of the value to use.
@@ -30,7 +31,7 @@ class Poller {
    * @param {string} rolePermittedAnnotation - namespace annotation that defines which roles can be assumed within this namespace
    * @param {Object} metrics - Metrics client.
    */
-  constructor ({
+  constructor({
     backends,
     intervalMilliseconds,
     kubeClient,
@@ -76,7 +77,7 @@ class Poller {
    * Create Kubernetes secret manifest.
    * @returns {Object} Promise object representing Kubernetes manifest.
    */
-  async _createSecretManifest () {
+  async _createSecretManifest() {
     const spec = this._spec
     const template = spec.template || {}
 
@@ -106,7 +107,7 @@ class Poller {
    * Poll Kubernetes secrets.
    * @returns {Promise} Promise object that always resolves.
    */
-  async _poll () {
+  async _poll() {
     this._logger.info(`running poll on the secret ${this._namespace}/${this._name}`)
 
     try {
@@ -136,7 +137,7 @@ class Poller {
    * Create or update Kubernetes secret in the cluster.
    * @returns {Promise} Promise object representing operation result.
    */
-  async _upsertKubernetesSecret () {
+  async _upsertKubernetesSecret() {
     const kubeNamespace = this._kubeClient.api.v1.namespaces(this._namespace)
 
     // check if namespace is allowed to fetch this secret
@@ -158,7 +159,7 @@ class Poller {
     }
   }
 
-  async _updateStatus (status) {
+  async _updateStatus(status) {
     try {
       this._logger.debug(`updating status for ${this._namespace}/${this._name} to: ${status}`)
       await this._status.put({
@@ -186,7 +187,7 @@ class Poller {
    * @param {Object} namespace namespace object
    * @param {Object} descriptor secret descriptor
    */
-  _isPermitted (namespace, descriptor) {
+  _isPermitted(namespace, descriptor) {
     const role = descriptor.roleArn
     let allowed = true
     let reason = ''
@@ -215,7 +216,7 @@ class Poller {
    * If current observed generation is older than ES generation it will poll right away
    * otherwise check when it was last polled and set timeout for next poll
    */
-  async _scheduleNextPoll () {
+  async _scheduleNextPoll() {
     try {
       const {
         body: {
@@ -259,7 +260,7 @@ class Poller {
    * Sets a timeout for the next poll
    * @param {number} nextPollIn - Trigger poll in this many miliseconds
    */
-  _setNextPoll (nextPollIn = this._intervalMilliseconds) {
+  _setNextPoll(nextPollIn = this._intervalMilliseconds) {
     if (this._timeoutId) {
       clearTimeout(this._timeoutId)
       this._timeoutId = null
@@ -274,7 +275,7 @@ class Poller {
    * @param {boolean} forcePoll - Trigger poll right away
    * @returns {Object} Poller instance.
    */
-  start () {
+  start() {
     if (this._timeoutId) return this
 
     this._logger.info(`starting poller for ${this._namespace}/${this._name}`)
@@ -287,7 +288,7 @@ class Poller {
    * Stop poller.
    * @returns {Object} Poller instance.
    */
-  stop () {
+  stop() {
     if (!this._timeoutId) return this
 
     this._logger.info(`stopping poller for ${this._namespace}/${this._name}`)


### PR DESCRIPTION
We have a special need which is to simplify the amount of times we have to input any given variable.

The ideia here is that we can fetch all keys inside a given path and export them as secret.
It saves the secrets by using the end of the path as the key instead of having to type them individually.

This setup with the k8s secretRef will mean that we only need to add a variable once in Parameter Store and it will automatically be available in the secrets file and on the pod without having to type it again.

The k8s setup in use is the following:
```
envFrom:
    - secretRef:
      name: ssm-test
```

Please keep in mind that I am not a programmer and you may find here a over complicated approach to this problem. 
The code in this PR is a mix of trial and error with a good amount of documentation and google search.

Let me know if you see this as a good addition to your service.
Thanks