### PR TITLE
Standardize CRD Spec

### DIFF
--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -247,10 +247,9 @@ spec:
     kind: SecretStore # ClusterSecretStore
     name: my-store
   target:
-    secret:
-      name: my-secret
-      template:
-        type: kubernetes.io/TLS
+    name: my-secret
+    template:
+      type: kubernetes.io/TLS
   data:
     tls.crt:
       key: /corp.org/dev/certs/ingress

--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -246,7 +246,7 @@ spec:
   storeRef:
     kind: SecretStore # ClusterSecretStore
     name: my-store
-  frontend:
+  target:
     secret:
       name: my-secret
       template:

--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -195,7 +195,7 @@ apiVerson: kes.io/v1alpha1
 kind: SecretBackend # or GlobalSecretBackend
 metadata:
   name: vault
-  namespace: example-ns # TODO: namespaced?
+  namespace: example-ns
 spec:
   vault:
     server: "https://vault.example.com"

--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -1,0 +1,163 @@
+```yaml
+---
+title: Standardize ExternalSecret CRD
+authors: all of us
+creation-date: 2020-09-01
+status: draft
+---
+```
+
+# Standardize ExternalSecret CRD
+
+## Table of Contents
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Terminology](#terminology)
+- [Use-Cases](#use-cases)
+- [Proposal](#proposal)
+  - [API](#api)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+This is a proposal to standardize the `ExternalSecret` CRD in an combined effort through all projects that deal with syncing external secrets. This proposal aims to do find the _common denominator_ for all users of `ExternalSecrets`.
+
+## Motivation
+
+There are a lot of different projects in the wild that essentially do the same thing: sync secrets with Kubernetes. The idea is to unify efforts into a single project that serves the needs of all users in this problem space.
+
+As a starting point i would like to define a **common denominator** for a CustomResourceDefinition that serves all known use-cases. This CRD should follow the standard alpha -> beta -> GA feature process.
+
+Once the CRD API is defined we can move on with more delicate discussions about technology, organization and processes.
+
+### Goals
+
+- Define a alpha CRD
+- Fully document the Spec and use-cases
+
+### Non-Goals
+
+This KEP proposes the CRD Spec and documents the use-cases, not the choice of technology or migration path towards implementing the CRD.
+
+## Terminology
+
+* Kubernetes External Secrets `KES`: A Application that runs a control loop which syncs secrets
+* KES `instance`: A single entity that runs a control loop.
+* ExternalSecret `ES`: A CustomResource that declares which secrets should be synced
+* Backend: A **source** for secrets. The Backend is external to the cluster. E.g.: Alibabacloud SecretsManager, AWS SystemsManager, Azure KeyVault...
+* Frontend: A **sink** for the synced secrets. Usually a `ConfigMap` or `Secret`
+* Secret: credentials that act as a key to sensitive information
+
+## Use-Cases
+
+The following use cases are taken from
+
+1. AS a KES user i want to run multiple KES instances per cluster (e.g. one KES instance per DEV/PROD)
+2. AS a KES user i want to integrate **multiple backends** from a **single KES instance** (e.g. dev namespace has access only to dev secrets)
+3. AS a KES user i want to control the sink for the secrets (aka frontend: store secret as `kind=ConfigMap` or `kind=Secret`)
+4. AS a KES user i want to fetch **from multiple** Backends and store the secrets **in a single** Frontend
+5. AS a KES operator i want to limit the access to certain backends or subresources (e.g. having one central KES instance that handles all ES - similar to `iam.amazonaws.com/permitted` annotation per namespace)
+
+## Proposal
+
+### API
+
+The `ExternalSecret` CustomResourceDefinition is **namespaced**. It defines the following:
+1. source for the secret (backend)
+2. sink for the secret (fronted)
+3. and a mapping to translate the keys
+
+```yaml
+apiVersion: kes.io/v1alpha1
+kind: ExternalSecret
+metadata: {...}
+
+spec:
+
+  # optional.
+  # used to select the correct KES instance (think: ingress.ingressClassName)
+  # There is no need for a indirection (e.g. having a extra resource like kind=IngressClass)
+  # the KES controller is instantiated with a specific class name
+  # and filters ES based on this property
+  externalSecretClassName: "dev"
+
+  # This is the "simple" version to specify a single backend which will be used by all keys
+  # we can have multiple backends per ES (they can be declared per key)
+  # Each backend does need a configuration (e.g. AWS IAM Roles, AWS Region, GCP project-id, )
+  backend:
+    type: secretsManager
+    # optional additional config
+    secretsManager:
+      region: eu-central-1
+      accessKeyID: AKIAIOSFODNN7EXAMPLE
+      roleARN: arn:aws:iam::YYYYYYYYYYYY:role/kes-full-access
+
+  # there can only be one frontend per ES
+  # this is the "thing" that is created by KES.
+  # conceptually speaking a frontend is just a thing that can hold k/v pairs
+  frontend:
+    secret:
+      # do we need a api version here? who handles upgrades?
+      apiVersion: v1
+      name: my-secret
+      template:
+        type: kubernetes.io/dockerconfigjson # or TLS...
+        metadata:
+          annotations: {}
+          labels: {}
+    # of course only one frontend should be defined
+    configMap:
+      # do we need a api version here? who handles upgrades?
+      apiVersion: v1 #
+      name: my-configmap
+      template:
+        metadata:
+          labels:
+            app: foo
+
+  data:
+    # EXAMPLE 1: simple mapping
+    # one key in a backend may hold multiple values
+    # we need a way to map the values to the frontend
+    # it is the responsibility of the backend implementation to know how to extract a value
+  - key: /corp.org/dev/certs/ingress
+    property: pubcert
+    name: tls.crt
+  - key: /corp.org/dev/certs/ingress
+    property: privkey
+    name: tls.key
+
+  # EXAMPLE 2: multiple backends per ES
+  # we also need a way to fetch secrets from multiple backend
+  # thus, we need a way to define a backend per data key
+  - key: /rds/database-secret
+    name: database
+    backend:
+      type: SecretsManager
+      secretsManager:
+        roleARN: arn:aws:iam::YYYYYYYYYYYY:role/kes-ssm-access
+  - key: /users/my-db-user
+    name: username
+    backend:
+      type: SystemsManager
+      systemsManager:
+        roleARN: arn:aws:iam::XXXXXXXXXXXX:role/kes-sm-access
+
+# status holds the timestamp and status of last last sync
+status:
+  lastSync: 2020-09-01T18:19:17.263Z # ISO 8601 date string
+  status: success # or failure
+
+```
+
+This API makes the options more explicit rather than having annotations.
+
+
+## Alternatives
+
+###

--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -117,13 +117,6 @@ metadata: {...}
 
 spec:
 
-  # optional.
-  # used to select the correct KES instance (think: ingress.ingressClassName)
-  # There is no need for a indirection (e.g. having a extra resource like kind=IngressClass)
-  # the KES controller is instantiated with a specific class name
-  # and filters ES based on this property
-  className: "dev"
-
   # the amount of time before the values will be read again from the store
   refreshInterval: "1h"
 
@@ -198,6 +191,12 @@ metadata:
   namespace: example-ns
 spec:
 
+  # optional.
+  # used to select the correct KES controller (think: ingress.ingressClassName)
+  # The KES controller is instantiated with a specific controller name
+  # and filters ES based on this property
+  controller: "dev"
+
   store:
     # store implementation
     vault:
@@ -236,8 +235,6 @@ spec:
 ```
 
 Workflow in a KES instance:
-1. A user creates a CRD with a certain `spec.externalSecretClassName`
-2. A controller picks up the `ExternalSecret` if it matches the `className`
-3. a) It fetches the `SecretStore` or `GlobalSecretStore` defined in `spec.storeRef` and applies it. This does also apply to `spec.data[].storeRef`
-
-## Alternatives
+1. A user creates a Store with a certain `spec.controller`
+2. A controller picks up the `ExternalSecret` if it matches the `controller` field
+3. The controller fetches the secret from the provider and stores it as kind=Secret in the same namespace as ES

--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -106,6 +106,13 @@ metadata: {...}
 
 spec:
 
+  # optional.
+  # used to select the correct KES instance (think: ingress.ingressClassName)
+  # There is no need for a indirection (e.g. having a extra resource like kind=IngressClass)
+  # the KES controller is instantiated with a specific class name
+  # and filters ES based on this property
+  className: "dev"
+
   # the amount of time before the values will be read again from the store
   refreshInterval: "1h"
 
@@ -187,12 +194,6 @@ metadata:
   name: vault
   namespace: example-ns
 spec:
-  # optional.
-  # used to select the correct KES instance (think: ingress.ingressClassName)
-  # There is no need for a indirection (e.g. having a extra resource like kind=IngressClass)
-  # the KES controller is instantiated with a specific class name
-  # and filters ES based on this property
-  externalSecretClassName: "dev"
 
   store:
     # store implementation
@@ -214,7 +215,6 @@ kind: ExternalSecret
 metadata:
   name: foo
 spec:
-  externalSecretClassName: "example"
   storeRef:
     kind: SecretStore # ClusterSecretStore
     name: my-store

--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -218,16 +218,12 @@ spec:
   controller: "dev"
 
   store:
-    # store implementation
-    vault:
+    type: vault
+    parameters: # provider specific k/v pairs
       server: "https://vault.example.com"
-      path: secret/data
-      auth:
-        kubernetes:
-          path: kubernetes
-          role: example-role
-          secretRef:
-            name: vault-secret
+      path: path/on/vault/store
+    auth: {} # provider specific k/v pairs
+
 status:
   # * Pending: e.g. referenced secret containing credentials is missing
   # * Running: all dependencies are met, sync

--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -118,6 +118,7 @@ metadata: {...}
 spec:
 
   # the amount of time before the values will be read again from the store
+  # may be set to zero to fetch and create it once
   refreshInterval: "1h"
 
   # there can only be one target per ES
@@ -193,8 +194,9 @@ status:
 
 ```
 
-This API makes the options more explicit rather than having annotations.
+#### Behavior
 
+The ExternalSecret control loop **ensures** that the target resource exists and stays up to date with the upstream provider. Because most upstream APIs are limited in throughput the control loop must implement some sort of jitter and retry/backoff mechanic.
 
 ### External Secret Store
 

--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -100,7 +100,7 @@ The `ExternalSecret` CustomResourceDefinition is **namespaced**. It defines the 
 3. and a mapping to translate the keys
 
 ```yaml
-apiVersion: kes.io/v1alpha1
+apiVersion: external-secrets.k8s.io/v1alpha1
 kind: ExternalSecret
 metadata: {...}
 
@@ -188,7 +188,7 @@ The store configuration in an `ExternalSecret` may contain a lot of redundancy, 
 These stores are defined in a particular namespace using `SecretStore` **or** globally with `GlobalSecretStore`.
 
 ```yaml
-apiVerson: kes.io/v1alpha1
+apiVerson: external-secrets.k8s.io/v1alpha1
 kind: SecretStore # or ClusterSecretStore
 metadata:
   name: vault
@@ -210,7 +210,7 @@ spec:
 
 Example Secret that uses the reference to a store
 ```yaml
-apiVersion: kes.io/v1alpha1
+apiVersion: external-secrets.k8s.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: foo

--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -79,6 +79,7 @@ These backends are relevant:
 * Azure Key Vault
 * Alibaba Cloud KMS Secret Manager
 * Google Cloud Platform Secret Manager
+* Kubernetes (see #422)
 * noop (see #476)
 
 ### Frontends

--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -175,10 +175,21 @@ spec:
   dataFrom:
   - key: /user/all-creds
 
-# status holds the timestamp and status of last last sync
 status:
-  lastSync: 2020-09-01T18:19:17.263Z # ISO 8601 date string
-  status: success # or failure
+  # represents the current phase of secret sync:
+  # * Pending | ES created, controller did not yet sync the ES or other dependencies are missing (e.g. secret store or configmap template)
+  # * Syncing | ES is being actively synced according to spec
+  # * Failing | Secret can not be synced, this might require user intervention
+  # * Failed  | ES can not be synced right now and will not able to
+  # * Completed | ES was synced successfully (one-time use only)
+  phase: Syncing
+  conditions:
+  - type: InSync
+    status: "True" # False if last sync was not successful
+    reason: "SecretSynced"
+    message: "Secret was synced"
+    lastTransitionTime: "2019-08-12T12:33:02Z"
+    lastSyncTime: "2020-09-23T16:27:53Z"
 
 ```
 
@@ -215,6 +226,16 @@ spec:
           role: example-role
           secretRef:
             name: vault-secret
+status:
+  # * Pending: e.g. referenced secret containing credentials is missing
+  # * Running: all dependencies are met, sync
+  phase: Running
+  conditions:
+  - type: Ready
+    status: "False"
+    reason: "ErrorConfig"
+    message: "Unable to assume role arn:xxxx"
+    lastTransitionTime: "2019-08-12T12:33:02Z"
 ```
 
 Example Secret that uses the reference to a store

--- a/keps/20200901-standard-crd.md
+++ b/keps/20200901-standard-crd.md
@@ -113,6 +113,9 @@ spec:
   # and filters ES based on this property
   externalSecretClassName: "dev"
 
+  # the amount of time before the values will be read again from the backen
+  refreshInterval: "1h"
+
   # This is the "simple" version to specify a single backend which will be used by all keys
   # we can have multiple backends per ES (they can be declared per key)
   # Each backend does need a configuration (e.g. AWS IAM Roles, AWS Region, GCP project-id, )


### PR DESCRIPTION
## Request for comments

The idea is to use this draft PR for discussing **only the CRD Spec** mentioned in #47.

:exclamation:  Technology discussions are off-topic

CHANGELOG:
* rename `backend`  to `store`
* remove inline `backend` from `ExternalSecret`
* rename `externalSecretClassName` to `className`
* integrate `dataFrom` into spec

TODO:
* [ ] how would one sync secrets within kubernetes (probably similar to `#474` w/ service accounts)?
