### PR TITLE
feat(multitenancy): Allow to watch ExternalSecrets in specific namespaces

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -36,5 +36,4 @@ jobs:
           helm init --client-only
         if: matrix.helmVersion == 'V2'
       - run: ./e2e/run-e2e-suite.sh ${{ matrix.disableCustomResourceManager }} ${{ matrix.helmVersion }}
-        env:
-          DEBUG: 'true'
+

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -36,3 +36,5 @@ jobs:
           helm init --client-only
         if: matrix.helmVersion == 'V2'
       - run: ./e2e/run-e2e-suite.sh ${{ matrix.disableCustomResourceManager }} ${{ matrix.helmVersion }}
+        env:
+          DEBUG: 'true'

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ metadata:
 ### Using ExternalSecret controller config
 
 ExternalSecret config allows scoping the access of kubernetes-external-secrets controller.
-This allows to deploy multi kubernetes-external-secrets instances at the same cluster
+This allows to deploy multi kubernetes-external-secrets instances in the same cluster
 and each instance can access a set of predefined namespaces.
 
 To enable this option, set the env var in the controller side with a list of namespaces:
@@ -271,12 +271,12 @@ env:
   WATCHED_NAMESPACES: "default,qa,dev"
 ```
 
-Finally, in case more than a kubernetes-external-secrets is deployment,
-it's recommended to make only one deployment is the CRD manager,
-and disable CRD management in the rest of the deployment
-to avoid having multiple deployments fighting over the CRD.
+Finally, in case more than one kubernetes-external-secrets is deployed,
+it's recommended to make only one deployment manage the CRDs.
+To disable CRD management in the other deployments,
+to avoid having them fighting over the CRD.
 
-That's could be done in the controller side by setting the env var:
+That can be done in the controller side by setting the env var:
 ```yaml
 env:
   DISABLE_CUSTOM_RESOURCE_MANAGER: true

--- a/README.md
+++ b/README.md
@@ -230,9 +230,12 @@ spec:
       name: .dockerconfigjson
 ```
 
-## Enforcing naming conventions for backend keys
+## Scoping access
 
-by default an `ExternalSecret` may access arbitrary keys from the backend e.g.
+### Using Namespace annotation
+
+Enforcing naming conventions for backend keys could be done by using namespace annotations.
+By default an `ExternalSecret` may access arbitrary keys from the backend e.g.
 
 ```yml
   data:
@@ -255,6 +258,31 @@ metadata:
     # annotation key is configurable
     externalsecrets.kubernetes-client.io/permitted-key-name: "/dev/cluster1/core-namespace/.*"
 ```
+
+### Using ExternalSecret controller config
+
+ExternalSecret config allows scoping the access of kubernetes-external-secrets controller.
+This allows to deploy multi kubernetes-external-secrets instances at the same cluster
+and each instance can access a set of predefined namespaces.
+
+To enable this option, set the env var in the controller side with a list of namespaces:
+```yaml
+env:
+  WATCHED_NAMESPACES: "default,qa,dev"
+```
+
+Finally, in case more than a kubernetes-external-secrets is deployment,
+it's recommended to make only one deployment is the CRD manager,
+and disable CRD management in the rest of the deployment
+to avoid having multiple deployments fighting over the CRD.
+
+That's could be done in the controller side by setting the env var:
+```yaml
+env:
+  DISABLE_CUSTOM_RESOURCE_MANAGER: true
+```
+
+Or in Helm, by setting `customResourceManagerDisabled=true`.
 
 ## Deprecations
 

--- a/bin/daemon.js
+++ b/bin/daemon.js
@@ -26,7 +26,8 @@ const {
   rolePermittedAnnotation,
   namingPermittedAnnotation,
   enforceNamespaceAnnotation,
-  watchTimeout
+  watchTimeout,
+  watchedNamespaces
 } = require('../config')
 
 async function main () {
@@ -37,6 +38,7 @@ async function main () {
 
   const externalSecretEvents = getExternalSecretEvents({
     kubeClient,
+    watchedNamespaces,
     customResourceManifest,
     logger,
     watchTimeout

--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -84,7 +84,7 @@ The following table lists the configurable parameters of the `kubernetes-externa
 | `env.VAULT_ADDR`                          | Endpoint for the Vault backend, if using Vault                                                                                    | `http://127.0.0.1:8200`                |
 | `env.DISABLE_POLLING`                     | Disables backend polling and only updates secrets when ExternalSecret is modified, setting this to any value will disable polling | `nil`                                 |
 | `env.WATCH_TIMEOUT`                     | Restarts the external secrets resource watcher if no events have been seen in this time period (miliseconds) | `60000`                                 |
-| `env.WATCHED_NAMESPACES`                     | Limits which namespaces the controller will watch, by default all namespaces will be watched | `''`                                 |
+| `env.WATCHED_NAMESPACES`                     | Limits which namespaces the controller will watch, by default all namespaces will be watched. Comma separated list `qa,stage` | `''`                                 |
 | `envVarsFromSecret.AWS_ACCESS_KEY_ID`     | Set AWS_ACCESS_KEY_ID (from a secret) in Deployment Pod                                                                           |                                       |
 | `envVarsFromSecret.AWS_SECRET_ACCESS_KEY` | Set AWS_SECRET_ACCESS_KEY (from a secret) in Deployment Pod                                                                       |                                       |
 | `envVarsFromSecret.AZURE_TENANT_ID`       | Set AZURE_TENANT_ID (from a secret) in Deployment Pod                                                                             |                                       |

--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -84,6 +84,7 @@ The following table lists the configurable parameters of the `kubernetes-externa
 | `env.VAULT_ADDR`                          | Endpoint for the Vault backend, if using Vault                                                                                    | `http://127.0.0.1:8200`                |
 | `env.DISABLE_POLLING`                     | Disables backend polling and only updates secrets when ExternalSecret is modified, setting this to any value will disable polling | `nil`                                 |
 | `env.WATCH_TIMEOUT`                     | Restarts the external secrets resource watcher if no events have been seen in this time period (miliseconds) | `60000`                                 |
+| `env.WATCHED_NAMESPACES`                     | Limits which namespaces the controller will watch, by default all namespaces will be watched | `''`                                 |
 | `envVarsFromSecret.AWS_ACCESS_KEY_ID`     | Set AWS_ACCESS_KEY_ID (from a secret) in Deployment Pod                                                                           |                                       |
 | `envVarsFromSecret.AWS_SECRET_ACCESS_KEY` | Set AWS_SECRET_ACCESS_KEY (from a secret) in Deployment Pod                                                                       |                                       |
 | `envVarsFromSecret.AZURE_TENANT_ID`       | Set AZURE_TENANT_ID (from a secret) in Deployment Pod                                                                             |                                       |

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -16,6 +16,7 @@ env:
   AWS_DEFAULT_REGION: us-west-2
   POLLER_INTERVAL_MILLISECONDS: 10000  # Caution, setting this frequency may incur additional charges on some platforms
   WATCH_TIMEOUT: 60000
+  WATCHED_NAMESPACES: '' # Comma separated list of namespaces, empty or unset means ALL namespaces.
   LOG_LEVEL: info
   LOG_MESSAGE_KEY: 'msg'
   # Print logs level as string ("info") rather than integer (30)

--- a/config/environment.js
+++ b/config/environment.js
@@ -41,6 +41,17 @@ const metricsPort = process.env.METRICS_PORT || 3001
 const customResourceManagerDisabled = 'DISABLE_CUSTOM_RESOURCE_MANAGER' in process.env
 const watchTimeout = process.env.WATCH_TIMEOUT ? parseInt(process.env.WATCH_TIMEOUT) : 60000
 
+// A comma-separated list of watched namespaces. If set, only ExternalSecrets in those namespaces will be handled.
+let watchedNamespaces = process.env.WATCHED_NAMESPACES || ''
+
+// Return an array after splitting the watched namespaces string and clean up user input.
+watchedNamespaces = watchedNamespaces
+  .split(',')
+  // Remove any extra spaces.
+  .map(namespace => { return namespace.trim() })
+  // Remove empty values (in case there is a tailing comma).
+  .filter(namespace => namespace)
+
 module.exports = {
   vaultEndpoint,
   vaultNamespace,
@@ -58,5 +69,6 @@ module.exports = {
   customResourceManagerDisabled,
   useHumanReadableLogLevels,
   logMessageKey,
-  watchTimeout
+  watchTimeout,
+  watchedNamespaces
 }

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -33,7 +33,7 @@ kind load docker-image --name="es-dev-cluster" external-secrets:test
 kubectl apply -f ./localstack.deployment.yaml
 
 # deploy external secrets
-helm template ../charts/kubernetes-external-secrets \
+helm template e2e ../charts/kubernetes-external-secrets \
   --set image.repository=external-secrets \
   --set image.tag=test \
   --set env.LOG_LEVEL=debug \

--- a/lib/external-secret.js
+++ b/lib/external-secret.js
@@ -24,33 +24,27 @@ function createEventQueue () {
 
 async function startWatcher ({
   kubeClient,
-  watchedNamespaces,
+  namespace,
   customResourceManifest,
   logger,
   eventQueue,
   watchTimeout
 }) {
   const deathQueue = createEventQueue()
+  const loggedNamespaceName = namespace || '*'
 
   try {
     while (true) {
-      logger.debug('Starting watch stream')
+      logger.debug('Starting watch stream for namespace %s', loggedNamespaceName)
+
+      const stream = kubeClient
+        .apis[customResourceManifest.spec.group]
+        .v1.watch
+        .namespaces(namespace)[customResourceManifest.spec.names.plural]
+        .getStream()
 
       const jsonStream = new JSONStream()
-
-      // If the watchedNamespaces is an empty array (i.e. no scoped access),
-      // add an empty element so all ExternalSecret resources in all namespaces will be watched.
-      const namespacesStreams = watchedNamespaces.length ? watchedNamespaces : ['']
-
-      // Create a namespace stream per namespace and add it to the JSON stream.
-      namespacesStreams.map(namespace => {
-        return kubeClient
-          .apis[customResourceManifest.spec.group]
-          .v1.watch
-          .namespaces(namespace)[customResourceManifest.spec.names.plural]
-          .getStream()
-          .pipe(jsonStream)
-      })
+      stream.pipe(jsonStream)
 
       let timeout
       const restartTimeout = () => {
@@ -60,10 +54,8 @@ async function startWatcher ({
 
         const timeMs = watchTimeout
         timeout = setTimeout(() => {
-          logger.info(`No watch event for ${timeMs} ms, restarting watcher`)
-          namespacesStreams.forEach(namespaceStream => {
-            namespaceStream.abort()
-          })
+          logger.info(`No watch event for ${timeMs} ms, restarting watcher for ${loggedNamespaceName}`)
+          stream.abort()
         }, timeMs)
         timeout.unref()
       }
@@ -74,7 +66,7 @@ async function startWatcher ({
       })
 
       jsonStream.on('error', (err) => {
-        logger.warn(err, 'Got error on stream')
+        logger.warn(err, 'Got error on stream for namespace %s', loggedNamespaceName)
         deathQueue.put('ERROR')
         clearTimeout(timeout)
       })
@@ -86,15 +78,14 @@ async function startWatcher ({
 
       const deathEvent = await deathQueue.take()
 
-      logger.info('Stopping watch stream due to event: %s', deathEvent)
+      logger.info('Stopping watch stream for namespace %s due to event: %s', loggedNamespaceName, deathEvent)
       eventQueue.put({ type: 'DELETED_ALL' })
 
-      namespacesStreams.forEach(namespaceStream => {
-        namespaceStream.abort()
-      })
+      stream.abort()
     }
   } catch (err) {
-    logger.error(err, 'Watcher crashed')
+    logger.error(err, 'Watcher for namespace %s crashed', loggedNamespaceName)
+    throw err
   }
 }
 
@@ -116,13 +107,20 @@ function getExternalSecretEvents ({
   return (async function * () {
     const eventQueue = createEventQueue()
 
-    startWatcher({
-      kubeClient,
-      watchedNamespaces,
-      customResourceManifest,
-      logger,
-      eventQueue,
-      watchTimeout
+    // If the watchedNamespaces is an empty array (i.e. no scoped access),
+    // add an empty element so all ExternalSecret resources in all namespaces will be watched.
+    const namespaceToWatch = watchedNamespaces.length ? watchedNamespaces : ['']
+
+    // Create watcher for each namespace
+    namespaceToWatch.forEach((namespace) => {
+      startWatcher({
+        namespace,
+        kubeClient,
+        customResourceManifest,
+        logger,
+        eventQueue,
+        watchTimeout
+      })
     })
 
     while (true) {

--- a/lib/external-secret.js
+++ b/lib/external-secret.js
@@ -24,6 +24,7 @@ function createEventQueue () {
 
 async function startWatcher ({
   kubeClient,
+  watchedNamespaces,
   customResourceManifest,
   logger,
   eventQueue,
@@ -35,13 +36,21 @@ async function startWatcher ({
     while (true) {
       logger.debug('Starting watch stream')
 
-      const stream = kubeClient
-        .apis[customResourceManifest.spec.group]
-        .v1.watch[customResourceManifest.spec.names.plural]
-        .getStream()
-
       const jsonStream = new JSONStream()
-      stream.pipe(jsonStream)
+
+      // If the watchedNamespaces is an empty array (i.e. no scoped access),
+      // add an empty element so all ExternalSecret resources in all namespaces will be watched.
+      const namespacesStreams = watchedNamespaces.length ? watchedNamespaces : ['']
+
+      // Create a namespace stream per namespace and add it to the JSON stream.
+      namespacesStreams.map(namespace => {
+        return kubeClient
+          .apis[customResourceManifest.spec.group]
+          .v1.watch
+          .namespaces(namespace)[customResourceManifest.spec.names.plural]
+          .getStream()
+          .pipe(jsonStream)
+      })
 
       let timeout
       const restartTimeout = () => {
@@ -52,7 +61,9 @@ async function startWatcher ({
         const timeMs = watchTimeout
         timeout = setTimeout(() => {
           logger.info(`No watch event for ${timeMs} ms, restarting watcher`)
-          stream.abort()
+          namespacesStreams.forEach(namespaceStream => {
+            namespaceStream.abort()
+          })
         }, timeMs)
         timeout.unref()
       }
@@ -78,7 +89,9 @@ async function startWatcher ({
       logger.info('Stopping watch stream due to event: %s', deathEvent)
       eventQueue.put({ type: 'DELETED_ALL' })
 
-      stream.abort()
+      namespacesStreams.forEach(namespaceStream => {
+        namespaceStream.abort()
+      })
     }
   } catch (err) {
     logger.error(err, 'Watcher crashed')
@@ -89,11 +102,13 @@ async function startWatcher ({
  * Get a stream of external secret events. This implementation uses
  * watch and yields as a stream of events.
  * @param {Object} kubeClient - Client for interacting with kubernetes cluster.
+ * @param {Array} watchedNamespaces - List of scoped namespaces.
  * @param {Object} customResourceManifest - Custom resource manifest.
  * @returns {Object} An async generator that yields externalsecret events.
  */
 function getExternalSecretEvents ({
   kubeClient,
+  watchedNamespaces,
   customResourceManifest,
   logger,
   watchTimeout
@@ -103,6 +118,7 @@ function getExternalSecretEvents ({
 
     startWatcher({
       kubeClient,
+      watchedNamespaces,
       customResourceManifest,
       logger,
       eventQueue,

--- a/lib/external-secret.test.js
+++ b/lib/external-secret.test.js
@@ -9,6 +9,7 @@ const { getExternalSecretEvents } = require('./external-secret')
 
 describe('getExternalSecretEvents', () => {
   let kubeClientMock
+  let watchedNamespaces
   let externalSecretsApiMock
   let fakeCustomResourceManifest
   let loggerMock
@@ -26,19 +27,29 @@ describe('getExternalSecretEvents', () => {
     externalSecretsApiMock = sinon.mock()
 
     mockedStream = new Readable()
-    mockedStream._read = () => {}
-    mockedStream.abort = () => {}
+    mockedStream._read = () => { }
 
     externalSecretsApiMock.get = sinon.stub()
-    kubeClientMock = sinon.mock()
-    kubeClientMock.apis = sinon.mock()
-    kubeClientMock.apis['kubernetes-client.io'] = sinon.mock()
-    kubeClientMock.apis['kubernetes-client.io'].v1 = sinon.mock()
-    kubeClientMock.apis['kubernetes-client.io'].v1.watch = sinon.mock()
-    kubeClientMock.apis['kubernetes-client.io']
-      .v1.watch.externalsecrets = sinon.mock()
-    kubeClientMock.apis['kubernetes-client.io']
-      .v1.watch.externalsecrets.getStream = () => mockedStream
+
+    kubeClientMock = {
+      apis: {
+        'kubernetes-client.io': {
+          v1: {
+            watch: {
+              namespaces: () => {
+                return {
+                  externalsecrets: {
+                    getStream: () => mockedStream
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    watchedNamespaces = []
 
     loggerMock = sinon.mock()
     loggerMock.info = sinon.stub()
@@ -60,6 +71,7 @@ describe('getExternalSecretEvents', () => {
 
     const events = getExternalSecretEvents({
       kubeClient: kubeClientMock,
+      watchedNamespaces: watchedNamespaces,
       customResourceManifest: fakeCustomResourceManifest,
       logger: loggerMock,
       watchTimeout: 5000


### PR DESCRIPTION
Hello,

This PR is 1 of 2 PRs to address support for multitenancy.

At the moment KES is not scoped, which means it works cluster-wide and there is no way to scope its access. Thus, cannot deploy 2 KES in the same cluster will different access.

So this PR allows allow to watch `externalsecrets` in specified namespaces which fix a couple of issues:
1. It allows to deploy more than 1 operator per cluster, so each tenant can deploy their own KES and optimize it according to thier workload.
2. Covers more use cases for security separation since using namespace annotation doesn't fit all use cases because in some workloads the tenant (e.g. devs) are able to create and edit namespaces.
3. Limit the access of KES service account (which used for Vault role for example) where it has gigantic access to all paths and policies in Vault for example. (this fixes issue no. #474)


I've already finished the main implementation (the last part could be supporting regex in namespaces name instead of static names), now I need to update the tests and docs.