### PR TITLE
Multitenancy: Allow to watch ExternalSecrets using annotation 

### DIFF
--- a/bin/daemon.js
+++ b/bin/daemon.js
@@ -25,7 +25,9 @@ const {
   pollingDisabled,
   rolePermittedAnnotation,
   namingPermittedAnnotation,
-  enforceNamespaceAnnotation
+  enforceNamespaceAnnotation,
+  instanceId,
+  managedByAnnotation
 } = require('../config')
 
 async function main () {
@@ -57,6 +59,8 @@ async function main () {
   })
 
   const daemon = new Daemon({
+    instanceId,
+    managedByAnnotation,
     externalSecretEvents,
     logger,
     pollerFactory

--- a/config/environment.js
+++ b/config/environment.js
@@ -40,6 +40,11 @@ const metricsPort = process.env.METRICS_PORT || 3001
 
 const customResourceManagerDisabled = 'DISABLE_CUSTOM_RESOURCE_MANAGER' in process.env
 
+// Set kubernetes-external-secret instance ID and manged-by annotation,
+// that will be used to decide which instance manages which externalsecret.
+const instanceId = process.env.INSTANCE_ID || ''
+const managedByAnnotation = process.env.MANAGED_BY_ANNOTATION || 'externalsecrets.kubernetes-client.io/managed-by'
+
 module.exports = {
   vaultEndpoint,
   vaultNamespace,
@@ -56,5 +61,7 @@ module.exports = {
   logLevel,
   customResourceManagerDisabled,
   useHumanReadableLogLevels,
-  logMessageKey
+  logMessageKey,
+  instanceId,
+  managedByAnnotation
 }

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -11,14 +11,17 @@ class Daemon {
    * @param {number} pollerIntervalMilliseconds - Interval time in milliseconds for polling secret properties.
    */
   constructor ({
+    instanceId,
+    managedByAnnotation,
     externalSecretEvents,
     logger,
     pollerFactory
   }) {
+    this._instanceId = instanceId
+    this._managedByAnnotation = managedByAnnotation
     this._externalSecretEvents = externalSecretEvents
     this._logger = logger
     this._pollerFactory = pollerFactory
-
     this._pollers = {}
   }
 
@@ -62,6 +65,17 @@ class Daemon {
    */
   async start () {
     for await (const event of this._externalSecretEvents) {
+      // Check if the externalSecret should be managed by this instance.
+      const externalSecretMetadata = event.object.metadata
+      if (externalSecretMetadata.annotations) {
+        const externalSecretManagedBy = externalSecretMetadata.annotations[this._managedByAnnotation] || ''
+        if (externalSecretManagedBy && this._instanceId !== externalSecretManagedBy) {
+          this._logger.debug('the secret %s/%s is not managed by this instance but by %s',
+            externalSecretMetadata.namespace, externalSecretMetadata.name, externalSecretManagedBy)
+          continue
+        }
+      }
+
       const descriptor = event.object ? this._createPollerDescriptor(event.object) : null
 
       switch (event.type) {

--- a/lib/daemon.test.js
+++ b/lib/daemon.test.js
@@ -15,6 +15,7 @@ describe('Daemon', () => {
   beforeEach(() => {
     loggerMock = sinon.mock()
     loggerMock.info = sinon.stub()
+    loggerMock.warn = sinon.stub()
     loggerMock.debug = sinon.stub()
 
     pollerMock = sinon.mock()
@@ -105,5 +106,64 @@ describe('Daemon', () => {
 
     expect(daemon._addPoller.called).to.equal(true)
     expect(daemon._removePoller.calledWith('test-id')).to.equal(true)
+  })
+
+  it('manage externalsecrets with matched managed-by annotation and instance id', async () => {
+    const fakeExternalSecretEvents = (async function * () {
+      yield {
+        type: 'ADDED',
+        object: {
+          metadata: {
+            name: 'foo',
+            namespace: 'foo',
+            uid: 'test-id',
+            annotations: {
+              'managed-by': 'instance01'
+            }
+          }
+        }
+      }
+    }())
+
+    daemon._instanceId = 'instance01'
+    daemon._managedByAnnotation = 'managed-by'
+    daemon._externalSecretEvents = fakeExternalSecretEvents
+    daemon._addPoller = sinon.mock()
+    daemon._removePoller = sinon.mock()
+
+    await daemon.start()
+    daemon.stop()
+
+    expect(daemon._addPoller.called).to.equal(true)
+    expect(daemon._removePoller.calledWith('test-id')).to.equal(true)
+  })
+
+  it('do not manage externalsecrets with unmatched managed-by annotation and instance id', async () => {
+    const fakeExternalSecretEvents = (async function * () {
+      yield {
+        object: {
+          type: 'ADDED',
+          metadata: {
+            name: 'foo',
+            namespace: 'foo',
+            uid: 'test-id',
+            annotations: {
+              'managed-by': 'instance01'
+            }
+          }
+        }
+      }
+    }())
+
+    daemon._instanceId = 'instance02'
+    daemon._managedByAnnotation = 'managed-by'
+    daemon._externalSecretEvents = fakeExternalSecretEvents
+    daemon._addPoller = sinon.mock()
+    daemon._removePoller = sinon.mock()
+
+    await daemon.start()
+    daemon.stop()
+
+    expect(daemon._addPoller.called).to.equal(false)
   })
 })


### PR DESCRIPTION
Hello,

This PR is 2 of 2 PRs to address support for multitenancy. The first PR is #548 

This PR adds a new option that allows to scope KES access by ExternalSecrets using annotation.
i.e. each ExternalSecret can tell which KES is responsible to manage that ExternalSecret.

This feature doesn't fix any security concerns like #548, but in combination with #548 it allows to have namespace scoped KES and global KES at the same time. So if there are 2 KES, there is no need to set namespaces for both of them as described in the other PR.

The feature implementation is done, and also the unit test. I just need to update the docs.