### PR TITLE
Corrected helm repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The official [helm chart](charts/kubernetes-external-secrets) can be used to cre
 
 
 ```bash
-$ helm repo add external-secrets https://godaddy.github.io/kubernetes-external-secrets/
+$ helm repo add external-secrets https://external-secrets.github.io/kubernetes-external-secrets/
 $ helm install external-secrets/kubernetes-external-secrets
 ```
 


### PR DESCRIPTION
Looks like the helm repo URL has changed and old URL is not valid anymore. If that is the would be better to update it in README