### PR TITLE
Add information on moving the repository from GoDaddy to external-secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 [![LGTM Alerts](https://img.shields.io/lgtm/alerts/github/godaddy/kubernetes-external-secrets)](https://lgtm.com/projects/g/godaddy/kubernetes-external-secrets)
 
+## ⚠️ Repository moved to external-secrets
+This project was moved from the [GoDaddy](https://github.com/godaddy) to the [external-secrets](https://github.com/external-secrets/kubernetes-external-secrets) GitHub organization in an effort to consolidate different projects with the same objective. More information [here](https://github.com/external-secrets/kubernetes-external-secrets/issues/554#issuecomment-728984416).
+
 # Kubernetes External Secrets
 
 Kubernetes External Secrets allows you to use external secret


### PR DESCRIPTION
Hey there!

Adding a more explicit header about moving the project to the new GitHub organization, since it could have generated problems we weren't aware of, like the Helm issue mentioned in the issue.