### PR TITLE
fix: annotation provided as list is not supported by k8s

### DIFF
--- a/lib/poller.js
+++ b/lib/poller.js
@@ -2,6 +2,7 @@
 
 const clonedeep = require('lodash.clonedeep')
 const merge = require('lodash.merge')
+const yaml = require("js-yaml")
 
 /**
  * Kubernetes secret descriptor.
@@ -211,8 +212,13 @@ class Poller {
     // 1. testing naming convention if defined in namespace
 
     const externalData = descriptor.data || descriptor.properties
-    const namingConvention = namespace.metadata.annotations[this._namingPermittedAnnotation]
+    let namingConvention = namespace.metadata.annotations[this._namingPermittedAnnotation]
     let reNaming = new RegExp()
+    if (!Array.isArray(namingConvention)) {
+      // Unmarshal YAML
+      namingConvention = yaml.safeLoad(namingConvention)
+    }
+
     if (Array.isArray(namingConvention)) {
       reNaming = new RegExp(namingConvention.join('|'))
     } else {

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -217,6 +217,13 @@ class Poller {
     if (!Array.isArray(namingConvention)) {
       // Unmarshal YAML
       namingConvention = yaml.safeLoad(namingConvention)
+      if (!Array.isArray(namingConvention) && typeof namingConvention !== 'string') {
+        allowed = false
+        reason = `Fail to parse ${this._namingPermittedAnnotation} on namespace ${namespace.metadata.name}.`
+        return {
+          allowed, reason
+        }
+      }
     }
 
     if (Array.isArray(namingConvention)) {

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -2,7 +2,7 @@
 
 const clonedeep = require('lodash.clonedeep')
 const merge = require('lodash.merge')
-const yaml = require("js-yaml")
+const yaml = require('js-yaml')
 
 /**
  * Kubernetes secret descriptor.

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -890,6 +890,17 @@ describe('Poller', () => {
         },
         {
           // test multiple regex data
+          ns: { metadata: { annotations: { [namingPermittedAnnotation]: '- dev/team-a/.*\n- common/.*' } } },
+          descriptor: {
+            data: [
+              { key: 'dev/team-a/ok-secret', name: 'somethingelse' },
+              { key: 'common/generic-secret', name: 'genericsecret' }
+            ]
+          },
+          permitted: true
+        },
+        {
+          // test multiple regex data
           ns: { metadata: { annotations: { [namingPermittedAnnotation]: ['dev/team-a/.*', 'common/.*'] } } },
           descriptor: {
             data: [


### PR DESCRIPTION
As reported by @ronlut (cf. https://github.com/external-secrets/kubernetes-external-secrets/pull/409#issuecomment-728855887), annotations value _should_ be of string type.

This PR and use of Yaml mutli-line string for `externalsecrets.kubernetes-client.io/permitted-key-name`
```bash
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Namespace
metadata:
  name: core-namespace
  annotations:
    # annotation key is configurable
    externalsecrets.kubernetes-client.io/permitted-key-name: |
      - "/dev/cluster1/core-namespace/.*"
      - "/common/.*"
EOF
```
should work.