### PR TITLE
Configure nestedKey in logger to avoid invalid json

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -41,7 +41,8 @@ const logger = pino({
     level (label, number) {
       return { level: envConfig.useHumanReadableLogLevels ? label : number }
     }
-  }
+  },
+  nestedKey: 'payload'
 })
 
 const customResourceManager = new CustomResourceManager({


### PR DESCRIPTION
The logger is generating a invalid json with duplicate keys in some circustances.

Use the nestedKey of the pino logger to avoid this issue, and log the objects under a "payload" key.

Example:

```
{
  "level": 50,
  "time": 1591347107037,
  "pid": 19,
  "payload": {
    "hostname": "kubernetes-external-secrets-6799c84569-kfjcj",
    "message": "Access to KMS is not allowed",
    "code": "AccessDeniedException",
    "time": "2020-06-05T08:51:47.036Z",
    "requestId": "1894b6c9-b698-4657-a3cb-ecd8f044afee",
    "statusCode": 400,
    "retryable": false,
    "retryDelay": 77.07928574264942,
    "stack": "AccessDeniedException: Access to KMS is not allowed\n    at Request.extractError (/app/node_modules/aws-sdk/lib/protocol/json.js:51:27)\n    at Request.callListeners (/app/node_modules/aws-sdk/lib/sequential_executor.js:106:20)\n    at Request.emit (/app/node_modules/aws-sdk/lib/sequential_executor.js:78:10)\n    at Request.emit (/app/node_modules/aws-sdk/lib/request.js:683:14)\n    at Request.transition (/app/node_modules/aws-sdk/lib/request.js:22:10)\n    at AcceptorStateMachine.runTo (/app/node_modules/aws-sdk/lib/state_machine.js:14:12)\n    at /app/node_modules/aws-sdk/lib/state_machine.js:26:10\n    at Request.<anonymous> (/app/node_modules/aws-sdk/lib/request.js:38:9)\n    at Request.<anonymous> (/app/node_modules/aws-sdk/lib/request.js:685:12)\n    at Request.callListeners (/app/node_modules/aws-sdk/lib/sequential_executor.js:116:18)",
    "type": "Error"
  },
  "msg": "failure while polling the secret kubernetes-external-secrets/test"
}
```

Solution proposed here https://github.com/external-secrets/kubernetes-external-secrets/issues/401#issuecomment-725069209

Related issue #401 
