### PR TITLE
fix(values): imagePullSecrets was wrongly indented under image

### DIFF
--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -77,7 +77,8 @@ image:
   repository: godaddy/kubernetes-external-secrets
   tag: 6.0.0
   pullPolicy: IfNotPresent
-  imagePullSecrets: []
+
+imagePullSecrets: []
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
closes #522

Readme and value usage already expects `imagePullSecrets` to be root level indentation.