### PR TITLE
use rbac.authorization.k8s.io/v1 for ClusterRole/Bindings where k8s >= 1.17

### DIFF
--- a/charts/kubernetes-external-secrets/templates/rbac.yaml
+++ b/charts/kubernetes-external-secrets/templates/rbac.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.rbac.create -}}
+{{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 kind: ClusterRole
 metadata:
   name: {{ include "kubernetes-external-secrets.fullname" . }}
@@ -31,7 +35,11 @@ rules:
     verbs: ["create"]
   {{- end }}
 ---
+{{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "kubernetes-external-secrets.fullname" . }}
@@ -49,7 +57,11 @@ subjects:
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
 ---
+{{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "kubernetes-external-secrets.fullname" . }}-auth


### PR DESCRIPTION
rebased version of #581 