### PR TITLE
feat: adds lodash get function for nested keys lookup

### DIFF
--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const AbstractBackend = require('./abstract-backend')
-const get = require('lodash/get')
+const { get, hasIn } = require('lodash')
 
 /** Key Value backend class. */
 class KVBackend extends AbstractBackend {
@@ -45,11 +45,11 @@ class KVBackend extends AbstractBackend {
           return
         }
 
-        if (!(get(parsedValue, property))) {
+        if (!(hasIn(parsedValue, property))) {
           throw new Error(`Could not find property ${property} in ${key}`)
         }
 
-        value = parsedValue[property]
+        value = get(parsedValue, property)
       }
 
       if (isBinary) {

--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const AbstractBackend = require('./abstract-backend')
-const get = require('lodash/get');
+const get = require('lodash/get')
 
 /** Key Value backend class. */
 class KVBackend extends AbstractBackend {

--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const AbstractBackend = require('./abstract-backend')
+const get = require('lodash/get');
 
 /** Key Value backend class. */
 class KVBackend extends AbstractBackend {
@@ -44,7 +45,7 @@ class KVBackend extends AbstractBackend {
           return
         }
 
-        if (!(property in parsedValue)) {
+        if (!(get(parsedValue, property))) {
           throw new Error(`Could not find property ${property} in ${key}`)
         }
 


### PR DESCRIPTION
Currently, with the Vault backend, only top-level properties can be used for formatting Secrets: [https://github.com/external-secrets/kubernetes-external-secrets/blob/master/lib/backends/kv-backend.js#L47](https://github.com/external-secrets/kubernetes-external-secrets/blob/master/lib/backends/kv-backend.js#L47)

We would like to be able to support nested property lookups for more complex Vault JSON secrets.

I added a simple lodash implementation to check whether the nested property exists, then fetch the value if it does.