### PR TITLE
feat(aws): allow custom endpoints for aws services

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Access to AWS secrets backends (SSM & secrets manager) can be granted in various
 
 4. Directly provide AWS access credentials to the `kubernetes-external-secrets` pod by environmental variables.
 
+5. Optionally configure AWS_STS_ENDPOINT, [AWS_SSM_ENDPOINT](https://docs.aws.amazon.com/general/latest/gr/ssm.html), [AWS_SM_ENDPOINT](https://docs.aws.amazon.com/general/latest/gr/asm.html).  Useful if you need to use the FIPS endpoints for compliance.
+
 ##### Using AWS access credentials
 
 Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars in the `kubernetes-external-secrets` session/pod.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ Access to AWS secrets backends (SSM & secrets manager) can be granted in various
 
 4. Directly provide AWS access credentials to the `kubernetes-external-secrets` pod by environmental variables.
 
-5. Optionally configure AWS_STS_ENDPOINT, [AWS_SSM_ENDPOINT](https://docs.aws.amazon.com/general/latest/gr/ssm.html), [AWS_SM_ENDPOINT](https://docs.aws.amazon.com/general/latest/gr/asm.html).  Useful if you need to use the FIPS endpoints for compliance.
+5. Optionally configure custom endpoints using environment variables
+    * [AWS_SM_ENDPOINT](https://docs.aws.amazon.com/general/latest/gr/asm.html) - Useful to set endpoints for FIPS compliance.
+    * [AWS_STS_ENDPOINT](https://docs.aws.amazon.com/general/latest/gr/sts.html) - Useful to set endpoints for FIPS compliance or regional latency.
+    * [AWS_SSM_ENDPOINT](https://docs.aws.amazon.com/general/latest/gr/ssm.html) - Useful to set endpoints for FIPS compliance or custom VPC endpoint.
+
 
 ##### Using AWS access credentials
 

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -25,6 +25,10 @@ env:
   # Set a role to be used when assuming roles specified in external secret (AWS only)
   # AWS_INTERMEDIATE_ROLE_ARN:
   # GOOGLE_APPLICATION_CREDENTIALS: /app/gcp-creds/gcp-creds.json
+  # Use custom endpoints for FIPS compliance
+  # AWS_STS_ENDPOINT: https://sts-fips.us-east-1.amazonaws.com
+  # AWS_SSM_ENDPOINT: http://ssm-fips.us-east-1.amazonaws.com
+  # AWS_SM_ENDPOINT: http://secretsmanager-fips.us-east-1.amazonaws.com
 
 # Create environment variables from existing k8s secrets
 # envVarsFromSecret:

--- a/config/aws-config.js
+++ b/config/aws-config.js
@@ -18,11 +18,27 @@ const localstack = process.env.LOCALSTACK || 0
 
 const intermediateRole = process.env.AWS_INTERMEDIATE_ROLE_ARN || 0
 
+const sts_endpoint = process.env.AWS_STS_ENDPOINT || 0
+const ssm_endpoint = process.env.AWS_SSM_ENDPOINT || 0
+const sm_endpoint = process.env.AWS_SM_ENDPOINT || 0
+
 let secretsManagerConfig = {}
 let systemManagerConfig = {}
 let stsConfig = {
   region: process.env.AWS_REGION || 'us-west-2',
   stsRegionalEndpoints: process.env.AWS_STS_ENDPOINT_TYPE || 'regional'
+}
+
+if (sm_endpoint) {
+  secretsManagerConfig.endpoint = sm_endpoint
+}
+
+if (ssm_endpoint) {
+  systemManagerConfig.endpoint = ssm_endpoint
+}
+
+if (sts_endpoint) {
+  stsConfig.endpoint = sts_endpoint
 }
 
 if (localstack) {

--- a/config/aws-config.js
+++ b/config/aws-config.js
@@ -18,9 +18,9 @@ const localstack = process.env.LOCALSTACK || 0
 
 const intermediateRole = process.env.AWS_INTERMEDIATE_ROLE_ARN || 0
 
-const sts_endpoint = process.env.AWS_STS_ENDPOINT || 0
-const ssm_endpoint = process.env.AWS_SSM_ENDPOINT || 0
-const sm_endpoint = process.env.AWS_SM_ENDPOINT || 0
+const stsEndpoint = process.env.AWS_STS_ENDPOINT || 0
+const ssmEndpoint = process.env.AWS_SSM_ENDPOINT || 0
+const smEndpoint = process.env.AWS_SM_ENDPOINT || 0
 
 let secretsManagerConfig = {}
 let systemManagerConfig = {}
@@ -29,16 +29,16 @@ let stsConfig = {
   stsRegionalEndpoints: process.env.AWS_STS_ENDPOINT_TYPE || 'regional'
 }
 
-if (sm_endpoint) {
-  secretsManagerConfig.endpoint = sm_endpoint
+if (smEndpoint) {
+  secretsManagerConfig.endpoint = smEndpoint
 }
 
-if (ssm_endpoint) {
-  systemManagerConfig.endpoint = ssm_endpoint
+if (ssmEndpoint) {
+  systemManagerConfig.endpoint = ssmEndpoint
 }
 
-if (sts_endpoint) {
-  stsConfig.endpoint = sts_endpoint
+if (stsEndpoint) {
+  stsConfig.endpoint = stsEndpoint
 }
 
 if (localstack) {


### PR DESCRIPTION
Allow custom endpoints for aws services

Useful if you need to use the FIPS endpoints ->  https://docs.aws.amazon.com/general/latest/gr/asm.html
Or less likely use case if you need to override to use VPC endpoints when using custom DNS -> https://docs.aws.amazon.com/secretsmanager/latest/userguide/vpc-endpoint-overview.html

kubernetes-external-secrets is amazing and FIPS support is required for running it in fedRAMP compliant environments.

Signed-off-by: S.Cavallo <smcavallo@hotmail.com>