### PR TITLE
add stale workflow to auto-close issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          stale-pr-message: 'This pr is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity.'
+          days-before-stale: 90
+          days-before-close: 30


### PR DESCRIPTION
This PR adds a workflow which runs daily to:
* mark issues without activity as `stale` after 90d
* close stale issues after 30d with no activity

See [actions/stale](https://github.com/actions/stale).

@Flydiverny could you plase take a look at this :heart:  ?