### PR TITLE
chore(docs): Fix README, `--generate-name` is missing in example command

### DIFF
--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -8,7 +8,7 @@ Assumes you are using Helm V3:
 
 ```bash
 $ helm repo add external-secrets https://external-secrets.github.io/kubernetes-external-secrets/
-$ helm install external-secrets/kubernetes-external-secrets --skip-crds
+$ helm install external-secrets/kubernetes-external-secrets --skip-crds --generate-name
 ```
 
 See below for [Helm V2 considerations](#helm-v2-considerations) when installing the chart.

--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -1,6 +1,6 @@
 # 💂 Kubernetes External Secrets
 
-[Kubernetes External Secrets](https://github.com/external-secrets/kubernetes-external-secrets) allows you to use external secret management systems (*e.g.*, [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/)) to securely add secrets in Kubernetes. Read more about the design and motivation for Kubernetes External Secrets on the [GoDaddy Engineering Blog](https://godaddy.github.io/2019/04/16/kubernetes-external-secrets/).
+[Kubernetes External Secrets](https://github.com/external-secrets/kubernetes-external-secrets) allows you to use external secret management systems (_e.g._, [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/)) to securely add secrets in Kubernetes. Read more about the design and motivation for Kubernetes External Secrets on the [GoDaddy Engineering Blog](https://godaddy.github.io/2019/04/16/kubernetes-external-secrets/).
 
 ## TL;DR;
 
@@ -15,7 +15,7 @@ See below for [Helm V2 considerations](#helm-v2-considerations) when installing 
 
 ## Prerequisites
 
-* Kubernetes 1.12+
+- Kubernetes 1.12+
 
 ## Installing the Chart
 
@@ -69,53 +69,53 @@ helm delete my-release
 
 The following table lists the configurable parameters of the `kubernetes-external-secrets` chart and their default values.
 
-| Parameter                                 | Description                                                                                                                       | Default                               |
-| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `crds.create`                             | For Helm V2 installations of the chart to install the CRD, for V3 installations use `--skip-crds` appropriately                   | `false`                               |
-| `customResourceManagerDisabled`           | Disables the custom resource manager, requiring the CRD be installed via the chart or other means                                 | `false`                               |
-| `env.AWS_REGION`                          | Set AWS_REGION in Deployment Pod                                                                                                  | `us-west-2`                           |
-| `env.AWS_INTERMEDIATE_ROLE_ARN`           | Specifies a role to be assumed before assuming role arn specified in external secrets                                             |                                       |
-| `env.LOG_LEVEL`                           | Set the application log level                                                                                                     | `info`                                |
-| `env.LOG_MESSAGE_KEY`                     | Set the key for log messages log text, for example when running on GCP it might be nice to set to `message`                       | `msg`                                 |
-| `env.USE_HUMAN_READABLE_LOG_LEVELS`       | Sets log levels as string instead of ints eg `info` instead of `30`, setting this to any value will switch                        | `nil`                                 |
-| `env.METRICS_PORT`                        | Specify the port for the prometheus metrics server                                                                                | `3001`                                |
-| `env.ROLE_PERMITTED_ANNOTATION`           | Specify the annotation key where to lookup the role arn permission boundaries                                                     | `iam.amazonaws.com/permitted`         |
-| `env.POLLER_INTERVAL_MILLISECONDS`        | Set POLLER_INTERVAL_MILLISECONDS in Deployment Pod                                                                                | `10000`                               |
-| `env.VAULT_ADDR`                          | Endpoint for the Vault backend, if using Vault                                                                                    | `http://127.0.0.1:8200`                |
-| `env.DISABLE_POLLING`                     | Disables backend polling and only updates secrets when ExternalSecret is modified, setting this to any value will disable polling | `nil`                                 |
-| `env.WATCH_TIMEOUT`                     | Restarts the external secrets resource watcher if no events have been seen in this time period (miliseconds) | `60000`                                 |
-| `env.WATCHED_NAMESPACES`                     | Limits which namespaces the controller will watch, by default all namespaces will be watched. Comma separated list `qa,stage` | `''`                                 |
-| `envVarsFromSecret.AWS_ACCESS_KEY_ID`     | Set AWS_ACCESS_KEY_ID (from a secret) in Deployment Pod                                                                           |                                       |
-| `envVarsFromSecret.AWS_SECRET_ACCESS_KEY` | Set AWS_SECRET_ACCESS_KEY (from a secret) in Deployment Pod                                                                       |                                       |
-| `envVarsFromSecret.AZURE_TENANT_ID`       | Set AZURE_TENANT_ID (from a secret) in Deployment Pod                                                                             |                                       |
-| `envVarsFromSecret.AZURE_CLIENT_ID`       | Set AZURE_CLIENT_ID (from a secret) in Deployment Pod                                                                             |                                       |
-| `envVarsFromSecret.AZURE_CLIENT_SECRET`   | Set AZURE_CLIENT_SECRET (from a secret) in Deployment Pod                                                                         |                                       |
-| `envVarsFromSecret.ALICLOUD_ENDPOINT`     | Set ALICLOUD_ENDPOINT for KMS Service in Deployment Pod                                                                           |                                       |
-| `envVarsFromSecret.ALICLOUD_ACCESS_KEY_ID`     | Set ALICLOUD_ACCESS_KEY_ID (from a secret) in Deployment Pod                                                                 |                                       |
-| `envVarsFromSecret.ALICLOUD_ACCESS_KEY_SECRET` | Set ALICLOUD_ACCESS_KEY_SECRET (from a secret) in Deployment Pod                                                             |                                       |
-| `image.repository`                        | kubernetes-external-secrets Image name                                                                                            | `godaddy/kubernetes-external-secrets` |
-| `image.tag`                               | kubernetes-external-secrets Image tag                                                                                             | `6.0.0`                               |
-| `image.pullPolicy`                        | Image pull policy                                                                                                                 | `IfNotPresent`                        |
-| `nameOverride`                            | Override the name of app                                                                                                          | `nil`                                 |
-| `fullnameOverride`                        | Override the full name of app                                                                                                     | `nil`                                 |
-| `rbac.create`                             | Create & use RBAC resources                                                                                                       | `true`                                |
-| `securityContext`                         | Pod-wide security context                                                                                                         | `{ runAsNonRoot: true }`              |
-| `serviceAccount.create`                   | Whether a new service account name should be created.                                                                             | `true`                                |
-| `serviceAccount.name`                     | Service account to be used.                                                                                                       | automatically generated               |
-| `serviceAccount.annotations`              | Annotations to be added to service account                                                                                        | `nil`                                 |
-| `podAnnotations`                          | Annotations to be added to pods                                                                                                   | `{}`                                  |
-| `podLabels`                               | Additional labels to be added to pods                                                                                             | `{}`                                  |
-| `priorityClassName`                       | Priority class to be assigned to pods
-| `replicaCount`                            | Number of replicas                                                                                                                | `1`                                   |
-| `nodeSelector`                            | node labels for pod assignment                                                                                                    | `{}`                                  |
-| `tolerations`                             | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                      | `[]`                                  |
-| `affinity`                                | Affinity for pod assignment                                                                                                       | `{}`                                  |
-| `resources`                               | Pod resource requests & limits                                                                                                    | `{}`                                  |
-| `dnsConfig`                               | Dns Config for pod.                                                                                                   | `{}`                                  |
-| `imagePullSecrets`                        | Reference to one or more secrets to be used when pulling images                                                                   | `[]`                                  |
-| `serviceMonitor.enabled`                  | Enable the creation of a serviceMonitor object for the Prometheus operator                                                        | `false`                               |
-| `serviceMonitor.interval`                 | The interval the Prometheus endpoint is scraped                                                                                   | `30s`                                 |
-| `serviceMonitor.namespace`                | The namespace where the serviceMonitor object has to be created                                                                   | `nil`                                 |
+| Parameter                                      | Description                                                                                                                       | Default                               |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `crds.create`                                  | For Helm V2 installations of the chart to install the CRD, for V3 installations use `--skip-crds` appropriately                   | `false`                               |
+| `customResourceManagerDisabled`                | Disables the custom resource manager, requiring the CRD be installed via the chart or other means                                 | `false`                               |
+| `env.AWS_REGION`                               | Set AWS_REGION in Deployment Pod                                                                                                  | `us-west-2`                           |
+| `env.AWS_INTERMEDIATE_ROLE_ARN`                | Specifies a role to be assumed before assuming role arn specified in external secrets                                             |                                       |
+| `env.LOG_LEVEL`                                | Set the application log level                                                                                                     | `info`                                |
+| `env.LOG_MESSAGE_KEY`                          | Set the key for log messages log text, for example when running on GCP it might be nice to set to `message`                       | `msg`                                 |
+| `env.USE_HUMAN_READABLE_LOG_LEVELS`            | Sets log levels as string instead of ints eg `info` instead of `30`, setting this to any value will switch                        | `nil`                                 |
+| `env.METRICS_PORT`                             | Specify the port for the prometheus metrics server                                                                                | `3001`                                |
+| `env.ROLE_PERMITTED_ANNOTATION`                | Specify the annotation key where to lookup the role arn permission boundaries                                                     | `iam.amazonaws.com/permitted`         |
+| `env.POLLER_INTERVAL_MILLISECONDS`             | Set POLLER_INTERVAL_MILLISECONDS in Deployment Pod                                                                                | `10000`                               |
+| `env.VAULT_ADDR`                               | Endpoint for the Vault backend, if using Vault                                                                                    | `http://127.0.0.1:8200`               |
+| `env.DISABLE_POLLING`                          | Disables backend polling and only updates secrets when ExternalSecret is modified, setting this to any value will disable polling | `nil`                                 |
+| `env.WATCH_TIMEOUT`                            | Restarts the external secrets resource watcher if no events have been seen in this time period (miliseconds)                      | `60000`                               |
+| `env.WATCHED_NAMESPACES`                       | Limits which namespaces the controller will watch, by default all namespaces will be watched. Comma separated list `qa,stage`     | `''`                                  |
+| `envVarsFromSecret.AWS_ACCESS_KEY_ID`          | Set AWS_ACCESS_KEY_ID (from a secret) in Deployment Pod                                                                           |                                       |
+| `envVarsFromSecret.AWS_SECRET_ACCESS_KEY`      | Set AWS_SECRET_ACCESS_KEY (from a secret) in Deployment Pod                                                                       |                                       |
+| `envVarsFromSecret.AZURE_TENANT_ID`            | Set AZURE_TENANT_ID (from a secret) in Deployment Pod                                                                             |                                       |
+| `envVarsFromSecret.AZURE_CLIENT_ID`            | Set AZURE_CLIENT_ID (from a secret) in Deployment Pod                                                                             |                                       |
+| `envVarsFromSecret.AZURE_CLIENT_SECRET`        | Set AZURE_CLIENT_SECRET (from a secret) in Deployment Pod                                                                         |                                       |
+| `envVarsFromSecret.ALICLOUD_ENDPOINT`          | Set ALICLOUD_ENDPOINT for KMS Service in Deployment Pod                                                                           |                                       |
+| `envVarsFromSecret.ALICLOUD_ACCESS_KEY_ID`     | Set ALICLOUD_ACCESS_KEY_ID (from a secret) in Deployment Pod                                                                      |                                       |
+| `envVarsFromSecret.ALICLOUD_ACCESS_KEY_SECRET` | Set ALICLOUD_ACCESS_KEY_SECRET (from a secret) in Deployment Pod                                                                  |                                       |
+| `image.repository`                             | kubernetes-external-secrets Image name                                                                                            | `godaddy/kubernetes-external-secrets` |
+| `image.tag`                                    | kubernetes-external-secrets Image tag                                                                                             | `6.0.0`                               |
+| `image.pullPolicy`                             | Image pull policy                                                                                                                 | `IfNotPresent`                        |
+| `nameOverride`                                 | Override the name of app                                                                                                          | `nil`                                 |
+| `fullnameOverride`                             | Override the full name of app                                                                                                     | `nil`                                 |
+| `rbac.create`                                  | Create & use RBAC resources                                                                                                       | `true`                                |
+| `securityContext`                              | Pod-wide security context                                                                                                         | `{ runAsNonRoot: true }`              |
+| `serviceAccount.create`                        | Whether a new service account name should be created.                                                                             | `true`                                |
+| `serviceAccount.name`                          | Service account to be used.                                                                                                       | automatically generated               |
+| `serviceAccount.annotations`                   | Annotations to be added to service account                                                                                        | `nil`                                 |
+| `podAnnotations`                               | Annotations to be added to pods                                                                                                   | `{}`                                  |
+| `podLabels`                                    | Additional labels to be added to pods                                                                                             | `{}`                                  |
+| `priorityClassName`                            | Priority class to be assigned to pods                                                                                             |
+| `replicaCount`                                 | Number of replicas                                                                                                                | `1`                                   |
+| `nodeSelector`                                 | node labels for pod assignment                                                                                                    | `{}`                                  |
+| `tolerations`                                  | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                      | `[]`                                  |
+| `affinity`                                     | Affinity for pod assignment                                                                                                       | `{}`                                  |
+| `resources`                                    | Pod resource requests & limits                                                                                                    | `{}`                                  |
+| `dnsConfig`                                    | Dns Config for pod.                                                                                                               | `{}`                                  |
+| `imagePullSecrets`                             | Reference to one or more secrets to be used when pulling images                                                                   | `[]`                                  |
+| `serviceMonitor.enabled`                       | Enable the creation of a serviceMonitor object for the Prometheus operator                                                        | `false`                               |
+| `serviceMonitor.interval`                      | The interval the Prometheus endpoint is scraped                                                                                   | `30s`                                 |
+| `serviceMonitor.namespace`                     | The namespace where the serviceMonitor object has to be created                                                                   | `nil`                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -145,7 +145,7 @@ aws secretsmanager create-secret --name hello-service/password --secret-string "
 and then create a `hello-service-external-secret.yml` file:
 
 ```yml
-apiVersion: 'kubernetes-client.io/v1'
+apiVersion: "kubernetes-client.io/v1"
 kind: ExternalSecret
 metadata:
   name: hello-service


### PR DESCRIPTION
While trying this awesome project, I found the example command which does not work.

```
$ helm install external-secrets/kubernetes-external-secrets --skip-crds
Error: must either provide a name or specify --generate-name
```

After adding `--generate-name`, it worked!

```
$ helm install external-secrets/kubernetes-external-secrets --skip-crds --generate-name
NAME: kubernetes-external-secrets-1612168415
LAST DEPLOYED: Mon Feb  1 17:33:37 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
The kubernetes external secrets has been installed. Check its status by running:
  kubectl --namespace default get pods -l "app.kubernetes.io/name=kubernetes-external-secrets,app.kubernetes.io/instance=kubernetes-external-secrets-1612168415"

Visit https://github.com/external-secrets/kubernetes-external-secrets for instructions on how to use kubernetes external secrets
```
