### PR TITLE
Add patch version semverCompare

### DIFF
--- a/charts/kubernetes-external-secrets/templates/rbac.yaml
+++ b/charts/kubernetes-external-secrets/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-  {{- if semverCompare ">=1.17.0" .Capabilities.KubeVersion.GitVersion -}}
+  {{- if semverCompare ">=1.17.0-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: rbac.authorization.k8s.io/v1
   {{- else -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
`.Capabilities.KubeVersion.GitVersion` has `-eks-<hash>` in EKS. e.g. `v1.19.6-eks-49a6c0`  
This semantic version was judged Prerelease version by semver function.
Prerelease version un comparable for release version.

As a workaround ref https://helm.sh/docs/chart_template_guide/function_list/#working-with-prerelease-versions

![image](https://user-images.githubusercontent.com/24284641/109128984-71518d80-7793-11eb-8c34-e5d25997c829.png)
