### PR TITLE
Enhance info log message about region for AWS SM backend

### DIFF
--- a/lib/backends/secrets-manager-backend.js
+++ b/lib/backends/secrets-manager-backend.js
@@ -27,7 +27,7 @@ class SecretsManagerBackend extends KVBackend {
    * @returns {Promise} Promise object representing secret property value.
    */
   async _get ({ key, specOptions: { roleArn, region }, keyOptions: { versionStage = 'AWSCURRENT', versionId = null } }) {
-    this._logger.info(`fetching secret property ${key} with role: ${roleArn || 'pods role'} in region ${region}`)
+    this._logger.info(`fetching secret property ${key} with role: ${roleArn || 'pods role'} in region: ${region || 'pods region'}`)
 
     let client = this._client
     let factoryArgs = null


### PR DESCRIPTION
This pull requests adds the following enhancement:

- An accurate info log message when the AWS region is not specified in the ExternalSecret manifest but uses the `AWS_REGION` env var as explained in https://github.com/external-secrets/kubernetes-external-secrets/issues/635

The idea is not to mislead the users by throwing an undefined in an info log message.

It is very small I know, but this simple addition can help not having any doubt about if external-secret is doing properly the task or not.