### PR TITLE
fix(vault): override api version for kv v2

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -77,7 +77,7 @@ if (envConfig.vaultNamespace) {
     'X-VAULT-NAMESPACE': envConfig.vaultNamespace
   }
 }
-const vaultFactory = () => vault(vaultOptions)
+const vaultFactory = (overrides = {}) => vault({ ...vaultOptions, ...overrides })
 
 // The Vault token is renewed only during polling, not asynchronously. The default tokenRenewThreshold
 // is three times larger than the pollerInterval so that the token is renewed before it

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -45,11 +45,11 @@ class VaultBackend extends KVBackend {
     const vaultMountPointGet = vaultMountPoint || this._defaultVaultMountPoint
     const vaultRoleGet = vaultRole || this._defaultVaultRole
     // Create cache key for auth specific client
-    const clientCacheKey = `|m${vaultMountPointGet}|r${vaultRoleGet}|`
+    const clientCacheKey = `|m${vaultMountPointGet}|r${vaultRoleGet}|kv${kvVersion}|`
     // Lookup existing or create new vault client
     let client = this._clients.get(clientCacheKey)
     if (!client) {
-      client = this._vaultFactory()
+      client = this._vaultFactory({ apiVersion: `v${kvVersion}` })
       this._clients.set(clientCacheKey, client)
     }
 


### PR DESCRIPTION
Not sure if this fixes things or not but was looking at #630 and https://github.com/kr1sp1n/node-vault/issues/82


Test image:
docker.io/flydiverny/kubernetes-external-secrets:vault-kv2-test

(this is untested, test at your own leisure)