### PR TITLE
Fixes Vault kv v1 issue #643 

### DIFF
--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -11,7 +11,6 @@ class VaultBackend extends KVBackend {
    * @param {Object} logger - Logger for logging stuff.
    */
   constructor ({ vaultFactory, tokenRenewThreshold, logger, defaultVaultMountPoint, defaultVaultRole }) {
-    debugger
     super({ logger })
     this._vaultFactory = vaultFactory
     this._clients = new Map()
@@ -57,6 +56,7 @@ class VaultBackend extends KVBackend {
     // If we already have a cached token then inspect it...
     if (client.token) {
       try {
+        this._logger.debug(`checking vault token expiry for role ${vaultRoleGet} on ${vaultMountPointGet}`)
         this._logger.debug(`checking vault token expiry for role ${vaultRoleGet} on ${vaultMountPointGet}`)
         const tokenStatus = await client.tokenLookupSelf()
         this._logger.debug(`vault token (role ${vaultRoleGet} on ${vaultMountPointGet}) valid for ${tokenStatus.data.ttl} seconds, renews at ${this._tokenRenewThreshold}`)

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -11,6 +11,7 @@ class VaultBackend extends KVBackend {
    * @param {Object} logger - Logger for logging stuff.
    */
   constructor ({ vaultFactory, tokenRenewThreshold, logger, defaultVaultMountPoint, defaultVaultRole }) {
+    debugger
     super({ logger })
     this._vaultFactory = vaultFactory
     this._clients = new Map()
@@ -41,7 +42,7 @@ class VaultBackend extends KVBackend {
    * @param {number} specOptions.kvVersion - K/V Version 1 or 2
    * @returns {Promise} Promise object representing secret property values.
    */
-  async _get ({ key, specOptions: { vaultMountPoint = null, vaultRole = null, kvVersion = 2 } }) {
+  async _get ({ key, specOptions: { vaultMountPoint = null, vaultRole = null, kvVersion = 1 } }) {
     const vaultMountPointGet = vaultMountPoint || this._defaultVaultMountPoint
     const vaultRoleGet = vaultRole || this._defaultVaultRole
     // Create cache key for auth specific client


### PR DESCRIPTION
Sets the default vault kv engine to version 1 instead of 2.  Until [kv versioning is fixed](https://github.com/kr1sp1n/node-vault/issues/82) in the upstream node-vault package, this should default to the working version.

closes https://github.com/external-secrets/kubernetes-external-secrets/issues/643