### PR TITLE
Enhance info log message about region for AWS System Manager backend

### DIFF
--- a/lib/backends/system-manager-backend.js
+++ b/lib/backends/system-manager-backend.js
@@ -24,10 +24,11 @@ class SystemManagerBackend extends KVBackend {
    * @returns {Promise} Promise object representing secret property value.
    */
   async _get ({ key, specOptions: { roleArn, region } }) {
+    this._logger.info(`fetching secret property ${key} with role: ${roleArn || 'pods role'} in region: ${region || 'pods region'}`)
+
     let client = this._client
     let factoryArgs = null
     if (roleArn) {
-      this._logger.info(`fetching secret property ${key} with role: ${roleArn} in region ${region}`)
       const credentials = this._assumeRole({
         RoleArn: roleArn,
         RoleSessionName: 'k8s-external-secrets'
@@ -36,9 +37,8 @@ class SystemManagerBackend extends KVBackend {
         ...factoryArgs,
         credentials
       }
-    } else {
-      this._logger.info(`fetching secret property ${key} with pod role in region ${region}`)
     }
+
     if (region) {
       factoryArgs = {
         ...factoryArgs,


### PR DESCRIPTION
## Description
- The secret manager was supported in the PR below, but it was supported because the system manager is not supported.

## FYI 
- https://github.com/external-secrets/kubernetes-external-secrets/pull/641