### PR TITLE
Update base image from 12.19.0-alpine to 12.21.0-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.19.0-alpine
+FROM node:12.21.0-alpine
 
 ENV NODE_ENV production
 ENV NPM_CONFIG_LOGLEVEL info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.21.0-alpine
+FROM node:12-alpine
 
 ENV NODE_ENV production
 ENV NPM_CONFIG_LOGLEVEL info


### PR DESCRIPTION
Hi,

this PR updates the Docker base image to the latest node 12 LTS minor release available on Docker Hub.

12.x is in maintenance mode until 2022-04-30. However, it should be considered to switch to the active LTS release 14.x which will be in maintenance mode until 2023-04-30. I am not sure how many breaking changes were introduced by node between 12.x and 14.x.

Best
Nick