### PR TITLE
fix: use getObjectStream to address deprecation warning in kubernetes-client

### DIFF
--- a/lib/external-secret.js
+++ b/lib/external-secret.js
@@ -50,7 +50,7 @@ async function startWatcher ({
         const timeMs = watchTimeout
         timeout = setTimeout(() => {
           logger.info(`No watch event for ${timeMs} ms, restarting watcher for ${loggedNamespaceName}`)
-          stream.abort()
+          stream.end()
         }, timeMs)
         timeout.unref()
       }
@@ -75,8 +75,7 @@ async function startWatcher ({
 
       logger.info('Stopping watch stream for namespace %s due to event: %s', loggedNamespaceName, deathEvent)
       eventQueue.put({ type: 'DELETED_ALL' })
-
-      stream.abort()
+      stream.end()
     }
   } catch (err) {
     logger.error(err, 'Watcher for namespace %s crashed', loggedNamespaceName)

--- a/lib/external-secret.js
+++ b/lib/external-secret.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const JSONStream = require('json-stream')
-
 /**
  * Creates an FIFO queue which you can put to and take from.
  * If theres nothing to take it will wait with resolving until
@@ -37,14 +35,11 @@ async function startWatcher ({
     while (true) {
       logger.debug('Starting watch stream for namespace %s', loggedNamespaceName)
 
-      const stream = kubeClient
+      const stream = await kubeClient
         .apis[customResourceManifest.spec.group]
         .v1.watch
         .namespaces(namespace)[customResourceManifest.spec.names.plural]
-        .getStream()
-
-      const jsonStream = new JSONStream()
-      stream.pipe(jsonStream)
+        .getObjectStream()
 
       let timeout
       const restartTimeout = () => {
@@ -60,18 +55,18 @@ async function startWatcher ({
         timeout.unref()
       }
 
-      jsonStream.on('data', (evt) => {
+      stream.on('data', (evt) => {
         eventQueue.put(evt)
         restartTimeout()
       })
 
-      jsonStream.on('error', (err) => {
+      stream.on('error', (err) => {
         logger.warn(err, 'Got error on stream for namespace %s', loggedNamespaceName)
         deathQueue.put('ERROR')
         clearTimeout(timeout)
       })
 
-      jsonStream.on('end', () => {
+      stream.on('end', () => {
         deathQueue.put('END')
         clearTimeout(timeout)
       })

--- a/lib/external-secret.test.js
+++ b/lib/external-secret.test.js
@@ -82,6 +82,7 @@ describe('getExternalSecretEvents', () => {
       }
     ])
 
+    fakeStream.end = sinon.stub()
     externalsecrets.getObjectStream = () => fakeStream
 
     const events = getExternalSecretEvents({

--- a/lib/external-secret.test.js
+++ b/lib/external-secret.test.js
@@ -10,10 +10,9 @@ const { getExternalSecretEvents } = require('./external-secret')
 describe('getExternalSecretEvents', () => {
   let kubeClientMock
   let watchedNamespaces
-  let externalSecretsApiMock
   let fakeCustomResourceManifest
   let loggerMock
-  let mockedStream
+  let externalsecrets
 
   beforeEach(() => {
     fakeCustomResourceManifest = {
@@ -24,12 +23,10 @@ describe('getExternalSecretEvents', () => {
         }
       }
     }
-    externalSecretsApiMock = sinon.mock()
 
-    mockedStream = new Readable()
-    mockedStream._read = () => { }
-
-    externalSecretsApiMock.get = sinon.stub()
+    externalsecrets = {
+      getObjectStream: () => undefined
+    }
 
     kubeClientMock = {
       apis: {
@@ -38,9 +35,7 @@ describe('getExternalSecretEvents', () => {
             watch: {
               namespaces: () => {
                 return {
-                  externalsecrets: {
-                    getStream: () => mockedStream
-                  }
+                  externalsecrets
                 }
               }
             }
@@ -69,6 +64,26 @@ describe('getExternalSecretEvents', () => {
       spec: { backendType: 'secretsManager', data: [] }
     }
 
+    const fakeStream = Readable.from([
+      {
+        type: 'MODIFIED',
+        object: fakeExternalSecretObject
+      },
+      {
+        type: 'ADDED',
+        object: fakeExternalSecretObject
+      },
+      {
+        type: 'DELETED',
+        object: fakeExternalSecretObject
+      },
+      {
+        type: 'DELETED_ALL'
+      }
+    ])
+
+    externalsecrets.getObjectStream = () => fakeStream
+
     const events = getExternalSecretEvents({
       kubeClient: kubeClientMock,
       watchedNamespaces: watchedNamespaces,
@@ -76,25 +91,6 @@ describe('getExternalSecretEvents', () => {
       logger: loggerMock,
       watchTimeout: 5000
     })
-
-    mockedStream.push(`${JSON.stringify({
-      type: 'MODIFIED',
-      object: fakeExternalSecretObject
-    })}\n`)
-
-    mockedStream.push(`${JSON.stringify({
-      type: 'ADDED',
-      object: fakeExternalSecretObject
-    })}\n`)
-
-    mockedStream.push(`${JSON.stringify({
-      type: 'DELETED',
-      object: fakeExternalSecretObject
-    })}\n`)
-
-    mockedStream.push(`${JSON.stringify({
-      type: 'DELETED_ALL'
-    })}\n`)
 
     const modifiedEvent = await events.next()
     expect(modifiedEvent.value.type).is.equal('MODIFIED')

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "6.3.0",
+      "version": "6.4.0",
       "license": "MIT",
       "dependencies": {
         "@alicloud/kms20160120": "^1.1.0",
@@ -15,7 +15,6 @@
         "aws-sdk": "^2.628.0",
         "express": "^4.17.1",
         "js-yaml": "^3.14.1",
-        "json-stream": "^1.0.0",
         "kubernetes-client": "^9.0.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.mapvalues": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "aws-sdk": "^2.628.0",
     "express": "^4.17.1",
     "js-yaml": "^3.14.1",
-    "json-stream": "^1.0.0",
     "kubernetes-client": "^9.0.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.mapvalues": "^4.6.0",


### PR DESCRIPTION
Signed-off-by: Markus Maga <markus@maga.se>