### PR TITLE
fix!: require .spec field in CRD validation

### DIFF
--- a/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
+++ b/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
@@ -31,6 +31,8 @@ spec:
 
   validation:
     openAPIV3Schema:
+      required:
+        - spec
       properties:
         spec:
           type: object

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -4,7 +4,7 @@ FROM node:12.21.0-alpine
 RUN mkdir /app
 WORKDIR /app
 COPY package.json package-lock.json /app/
-RUN npm install
+RUN npm ci
 
 # Copy app to source directory
 COPY . /app

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -21,7 +21,7 @@ To better understand how they are being run take a look at `run-e2e-suite.sh`.
 kind create cluster \
   --name es-dev-cluster \
   --config ./kind.yaml \
-  --image "kindest/node:v1.15.3"
+  --image "kindest/node:v1.16.15"
 
 export KUBECONFIG="$(kind get kubeconfig-path --name="es-dev-cluster")"
 

--- a/e2e/run-e2e-suite.sh
+++ b/e2e/run-e2e-suite.sh
@@ -68,10 +68,8 @@ trap cleanup EXIT
 kubectl apply -f ${DIR}/localstack.deployment.yaml
 
 CHART_DIR="$(dirname "$DIR")/charts/kubernetes-external-secrets"
-HELM_TEMPLATE_ARGS="e2e ${CHART_DIR}"
 
-helm template ${HELM_TEMPLATE_ARGS} \
-  --include-crds \
+helm install e2e ${CHART_DIR} \
   --set image.repository=external-secrets \
   --set image.tag=test \
   --set env.LOG_LEVEL=debug \
@@ -83,7 +81,7 @@ helm template ${HELM_TEMPLATE_ARGS} \
   --set env.AWS_DEFAULT_REGION=us-east-1 \
   --set env.AWS_REGION=us-east-1 \
   --set env.POLLER_INTERVAL_MILLISECONDS=1000 \
-  --set env.LOCALSTACK_STS_URL=http://sts | kubectl apply -f -
+  --set env.LOCALSTACK_STS_URL=http://sts
 
 echo -e "${BGREEN}Granting permissions to external-secrets e2e service account...${NC}"
 kubectl create serviceaccount external-secrets-e2e || true

--- a/e2e/tests/crd.test.js
+++ b/e2e/tests/crd.test.js
@@ -27,7 +27,7 @@ describe('CRD', () => {
   })
 
   it('should reject invalid ExternalSecret manifests', async () => {
-    kubeClient
+    return kubeClient
       .apis[customResourceManifest.spec.group]
       .v1.namespaces('default')[customResourceManifest.spec.names.plural]
       .post({
@@ -48,6 +48,7 @@ describe('CRD', () => {
           }
         }
       })
-      .catch(err => expect(err).to.be.an('error'))
+      .then(() => { throw new Error('was not supposed to succeed') })
+      .catch((err) => expect(err).to.match(/spec: Required value/))
   })
 })


### PR DESCRIPTION
Cherry picks from #681 

- fix invalid CRD test
- add test for template.type