### PR TITLE
fix: update transitive netmask dependency to resolve CVE-2021-28918

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8030,9 +8030,9 @@
       "dev": true
     },
     "node_modules/netmask": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -8891,13 +8891,13 @@
       }
     },
     "node_modules/pac-resolver": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.1.0.tgz",
-      "integrity": "sha512-d6lf2IrZJJ7ooVHr7BfwSjRO1yKSJMaiiWYSHcrxSIUtZrCa4KKGwcztdkZ/E9LFleJfjoi1yl+XLR7AX24nbQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
+      "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
       "dependencies": {
         "degenerator": "^2.2.0",
         "ip": "^1.1.5",
-        "netmask": "^1.0.6"
+        "netmask": "^2.0.1"
       },
       "engines": {
         "node": ">= 6"
@@ -18272,9 +18272,9 @@
       "dev": true
     },
     "netmask": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
     },
     "nise": {
       "version": "4.1.0",
@@ -18939,13 +18939,13 @@
       }
     },
     "pac-resolver": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.1.0.tgz",
-      "integrity": "sha512-d6lf2IrZJJ7ooVHr7BfwSjRO1yKSJMaiiWYSHcrxSIUtZrCa4KKGwcztdkZ/E9LFleJfjoi1yl+XLR7AX24nbQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
+      "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
       "requires": {
         "degenerator": "^2.2.0",
         "ip": "^1.1.5",
-        "netmask": "^1.0.6"
+        "netmask": "^2.0.1"
       }
     },
     "package-hash": {


### PR DESCRIPTION
Closes #690 