### PR TITLE
fix: bump Helm chart API version

### DIFF
--- a/charts/kubernetes-external-secrets/Chart.yaml
+++ b/charts/kubernetes-external-secrets/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: kubernetes-external-secrets
 version: 7.0.0
 appVersion: 7.0.0


### PR DESCRIPTION
This addresses #697. Lemme know if I overlooked something.