### PR TITLE
feat(Multitenancy): scope KES access using ExternalSecret config

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ kind: ExternalSecret
 metadata:
   name: foo
 spec:
-  controllerID: 'dev-team-instance'
+  controllerId: 'dev-team-instance'
 [...]
 ```
 

--- a/README.md
+++ b/README.md
@@ -361,19 +361,6 @@ $ kubectl get secret/tmpl-ext-sec -ogo-template='{{ .metadata.labels }}'
 map[label1:11 label2:hello-world]
 ```
 
-## Disabling custom resource manager
-
-In case there is more than one kubernetes-external-secrets deployment, it's recommended to disable CRD manager
-to avoid having multiple deployments fighting over the CRD.
-
-That's could be done in the controller side by setting the env var:
-```yaml
-env:
-  DISABLE_CUSTOM_RESOURCE_MANAGER: true
-```
-
-Or in Helm, by setting `customResourceManagerDisabled=true`.
-
 ## Scoping access
 
 ### Using Namespace annotation

--- a/README.md
+++ b/README.md
@@ -361,6 +361,19 @@ $ kubectl get secret/tmpl-ext-sec -ogo-template='{{ .metadata.labels }}'
 map[label1:11 label2:hello-world]
 ```
 
+## Disabling custom resource manager
+
+In case there is more than one kubernetes-external-secrets deployment, it's recommended to disable CRD manager
+to avoid having multiple deployments fighting over the CRD.
+
+That's could be done in the controller side by setting the env var:
+```yaml
+env:
+  DISABLE_CUSTOM_RESOURCE_MANAGER: true
+```
+
+Or in Helm, by setting `customResourceManagerDisabled=true`.
+
 ## Scoping access
 
 ### Using Namespace annotation
@@ -402,6 +415,35 @@ To enable this option, set the env var in the controller side with a list of nam
 env:
   WATCHED_NAMESPACES: "default,qa,dev"
 ```
+
+### Using ExternalSecret config
+
+ExternalSecret manifest allows scoping the access of kubernetes-external-secrets controller.
+This allows to deploy multi kubernetes-external-secrets instances at the same cluster
+and each instance can access a set of ExternalSecrets.
+
+To enable this option, set the env var in the controller side:
+```yaml
+env:
+  INSTANCE_ID: "dev-team-instance"
+```
+
+And in ExternalSecret side:
+```yaml
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: foo
+spec:
+  controllerID: 'dev-team-instance'
+[...]
+```
+
+**Please note**
+
+Scoping access by ExternalSecret config provides only a logical separation and it doesn't cover the security aspects.
+i.e it assumes that the security side is managed by another component like Kubernetes Network policies
+or Open Policy Agent.
 
 ## Deprecations
 

--- a/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
+++ b/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
@@ -42,6 +42,10 @@ spec:
                 any existing fields. into generated secret, can be used to
                 set for example annotations or type on the generated secret
               type: object
+            controllerID:
+              description: The ID of controller instance that manages this ExternalSecret.
+                This is needed in case there is more than a KES controller instances within the cluster.
+              type: string
             backendType:
               type: string
               enum:

--- a/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
+++ b/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
@@ -42,7 +42,7 @@ spec:
                 any existing fields. into generated secret, can be used to
                 set for example annotations or type on the generated secret
               type: object
-            controllerID:
+            controllerId:
               description: The ID of controller instance that manages this ExternalSecret.
                 This is needed in case there is more than a KES controller instances within the cluster.
               type: string

--- a/config/environment.js
+++ b/config/environment.js
@@ -16,6 +16,10 @@ if (environment === 'development') {
   require('dotenv').config()
 }
 
+// The name of this KES instance which used to scope access of ExternalSecrets.
+// This is needed in case there is more than a KES controller instances within the cluster.
+const instanceId = process.env.INSTANCE_ID || ''
+
 const vaultEndpoint = process.env.VAULT_ADDR || 'http://127.0.0.1:8200'
 // Grab the vault namespace from the environment
 const vaultNamespace = process.env.VAULT_NAMESPACE || null
@@ -52,6 +56,7 @@ watchedNamespaces = watchedNamespaces
   .filter(namespace => namespace)
 
 module.exports = {
+  instanceId,
   vaultEndpoint,
   vaultNamespace,
   vaultTokenRenewThreshold,

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -11,10 +11,12 @@ class Daemon {
    * @param {number} pollerIntervalMilliseconds - Interval time in milliseconds for polling secret properties.
    */
   constructor ({
+    instanceId,
     externalSecretEvents,
     logger,
     pollerFactory
   }) {
+    this._instanceId = instanceId
     this._externalSecretEvents = externalSecretEvents
     this._logger = logger
     this._pollerFactory = pollerFactory
@@ -62,6 +64,16 @@ class Daemon {
    */
   async start () {
     for await (const event of this._externalSecretEvents) {
+      // Check if the externalSecret should be managed by this instance.
+      if (event.object.spec) {
+        const externalSecretMetadata = event.object.metadata
+        const externalSecretController = event.object.spec.controllerID
+        if (externalSecretController && this._instanceId !== externalSecretController) {
+          this._logger.debug('the secret %s/%s is not managed by this instance but by %s',
+            externalSecretMetadata.namespace, externalSecretMetadata.name, externalSecretController)
+        }
+      }
+
       const descriptor = event.object ? this._createPollerDescriptor(event.object) : null
 
       switch (event.type) {

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -67,10 +67,11 @@ class Daemon {
       // Check if the externalSecret should be managed by this instance.
       if (event.object.spec) {
         const externalSecretMetadata = event.object.metadata
-        const externalSecretController = event.object.spec.controllerID
-        if (externalSecretController && this._instanceId !== externalSecretController) {
+        const externalSecretController = event.object.spec.controllerId
+        if ((this._instanceId || externalSecretController) && this._instanceId !== externalSecretController) {
           this._logger.debug('the secret %s/%s is not managed by this instance but by %s',
             externalSecretMetadata.namespace, externalSecretMetadata.name, externalSecretController)
+          continue
         }
       }
 

--- a/lib/daemon.test.js
+++ b/lib/daemon.test.js
@@ -119,7 +119,7 @@ describe('Daemon', () => {
             uid: 'test-id'
           },
           spec: {
-            controllerID: 'instance01'
+            controllerId: 'instance01'
           }
         }
       }
@@ -140,15 +140,15 @@ describe('Daemon', () => {
   it('do not manage externalsecrets with unmatched controller id and instance id', async () => {
     const fakeExternalSecretEvents = (async function * () {
       yield {
+        type: 'ADDED',
         object: {
-          type: 'ADDED',
           metadata: {
             name: 'foo',
             namespace: 'foo',
             uid: 'test-id'
           },
           spec: {
-            controllerID: 'instance01'
+            controllerId: 'instance01'
           }
         }
       }

--- a/lib/daemon.test.js
+++ b/lib/daemon.test.js
@@ -15,6 +15,7 @@ describe('Daemon', () => {
   beforeEach(() => {
     loggerMock = sinon.mock()
     loggerMock.info = sinon.stub()
+    loggerMock.warn = sinon.stub()
     loggerMock.debug = sinon.stub()
 
     pollerMock = sinon.mock()
@@ -105,5 +106,62 @@ describe('Daemon', () => {
 
     expect(daemon._addPoller.called).to.equal(true)
     expect(daemon._removePoller.calledWith('test-id')).to.equal(true)
+  })
+
+  it('manage externalsecrets with unmatched controller id and instance id', async () => {
+    const fakeExternalSecretEvents = (async function * () {
+      yield {
+        type: 'ADDED',
+        object: {
+          metadata: {
+            name: 'foo',
+            namespace: 'foo',
+            uid: 'test-id'
+          },
+          spec: {
+            controllerID: 'instance01'
+          }
+        }
+      }
+    }())
+
+    daemon._instanceId = 'instance01'
+    daemon._externalSecretEvents = fakeExternalSecretEvents
+    daemon._addPoller = sinon.mock()
+    daemon._removePoller = sinon.mock()
+
+    await daemon.start()
+    daemon.stop()
+
+    expect(daemon._addPoller.called).to.equal(true)
+    expect(daemon._removePoller.calledWith('test-id')).to.equal(true)
+  })
+
+  it('do not manage externalsecrets with unmatched controller id and instance id', async () => {
+    const fakeExternalSecretEvents = (async function * () {
+      yield {
+        object: {
+          type: 'ADDED',
+          metadata: {
+            name: 'foo',
+            namespace: 'foo',
+            uid: 'test-id'
+          },
+          spec: {
+            controllerID: 'instance01'
+          }
+        }
+      }
+    }())
+
+    daemon._instanceId = 'instance02'
+    daemon._externalSecretEvents = fakeExternalSecretEvents
+    daemon._addPoller = sinon.mock()
+    daemon._removePoller = sinon.mock()
+
+    await daemon.start()
+    daemon.stop()
+
+    expect(daemon._addPoller.called).to.equal(false)
   })
 })


### PR DESCRIPTION
As discussed in PR #549 but using the `spec.controllerId` instead of the annotation as @Flydiverny suggested.