### PR TITLE
Update README.md - Fix helm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The official [helm chart](charts/kubernetes-external-secrets) can be used to cre
 
 ```bash
 $ helm repo add external-secrets https://external-secrets.github.io/kubernetes-external-secrets/
-$ helm install external-secrets/kubernetes-external-secrets
+$ helm install kes external-secrets/kubernetes-external-secrets
 ```
 
 For more details about configuration see the [helm chart docs](charts/kubernetes-external-secrets/README.md)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The official [helm chart](charts/kubernetes-external-secrets) can be used to cre
 
 ```bash
 $ helm repo add external-secrets https://external-secrets.github.io/kubernetes-external-secrets/
-$ helm install kes external-secrets/kubernetes-external-secrets
+$ helm install [RELEASE_NAME] external-secrets/kubernetes-external-secrets
 ```
 
 For more details about configuration see the [helm chart docs](charts/kubernetes-external-secrets/README.md)

--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -6,7 +6,7 @@
 
 ```bash
 $ helm repo add external-secrets https://external-secrets.github.io/kubernetes-external-secrets/
-$ helm install external-secrets/kubernetes-external-secrets
+$ helm install [RELEASE_NAME] external-secrets/kubernetes-external-secrets
 ```
 
 See below for [Helm V2 considerations](#helm-v2-considerations) when installing the chart.


### PR DESCRIPTION
The helm install command is missing the name parameter, so it does not work on helm 3.2.1 at least.