### PR TITLE
Fix startup crash and ignore vscode config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ e2e/**/.kubeconfig
 
 # IDE
 .idea/
+.vscode/

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -65,7 +65,7 @@ class Daemon {
   async start () {
     for await (const event of this._externalSecretEvents) {
       // Check if the externalSecret should be managed by this instance.
-      if (event.object.spec) {
+      if (event.object && event.object.spec) {
         const externalSecretMetadata = event.object.metadata
         const externalSecretController = event.object.spec.controllerId
         if ((this._instanceId || externalSecretController) && this._instanceId !== externalSecretController) {


### PR DESCRIPTION
The check to see if a externalSecret should be managed by the running instance is not properly checking if `event.object` is present before evaluating the `spec` field.