### PR TITLE
Support path for vault-backend

### DIFF
--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -99,6 +99,25 @@ class VaultBackend extends KVBackend {
 
     throw new Error('Unknown "kvVersion" specified')
   }
+
+  /**
+   * Get secret property value from Vault.
+   * @param {string} path - Path to the Secret in the backend.
+   * @param {object} keyOptions - Options for this specific key, eg version etc.
+   * @param {object} specOptions - Options for this external secret, eg role
+   * @param {string} specOptions.vaultMountPoint - mount point
+   * @param {string} specOptions.vaultRole - role
+   * @param {number} specOptions.kvVersion - K/V Version 1 or 2
+   * @returns {Promise} Promise object representing secret property values.
+   */
+  async _getByPath ({ path, specOptions }) {
+    // The vault "key" in _get is actually the entire secret, so we can reuse this method.
+    const secretString = await this._get({ key: path, specOptions })
+    // this isn't great, but that's the way it goes w/ inheritance.
+    // basically we we are fulfilling the contract expected by our base class.
+    const secret = JSON.parse(secretString)
+    return secret
+  }
 }
 
 module.exports = VaultBackend

--- a/lib/backends/vault-backend.test.js
+++ b/lib/backends/vault-backend.test.js
@@ -65,30 +65,60 @@ describe('VaultBackend', () => {
     })
   })
 
-  describe('_get', () => {
-    beforeEach(() => {
-      clientMock.read = sinon.stub().returns(kv2Secret)
-      clientMock.token = undefined
-      clientMock.tokenLookupSelf = sinon.stub().returns(mockTokenLookupResultMustRenew)
-      clientMock.tokenRenewSelf = sinon.stub().returns(true)
-      clientMock.kubernetesLogin = sinon.stub().returns({
-        auth: {
-          client_token: '1234'
-        }
-      })
-
-      clientMock2.read = sinon.stub().returns(kv2Secret)
-      clientMock2.token = undefined
-      clientMock2.tokenLookupSelf = sinon.stub().returns(mockTokenLookupResultMustRenew)
-      clientMock2.tokenRenewSelf = sinon.stub().returns(true)
-      clientMock2.kubernetesLogin = sinon.stub().returns({
-        auth: {
-          client_token: '5678'
-        }
-      })
-
-      vaultBackend._fetchServiceAccountToken = sinon.stub().returns(jwt)
+  const setup = () => {
+    clientMock.read = sinon.stub().returns(kv2Secret)
+    clientMock.token = undefined
+    clientMock.tokenLookupSelf = sinon.stub().returns(mockTokenLookupResultMustRenew)
+    clientMock.tokenRenewSelf = sinon.stub().returns(true)
+    clientMock.kubernetesLogin = sinon.stub().returns({
+      auth: {
+        client_token: '1234'
+      }
     })
+
+    clientMock2.read = sinon.stub().returns(kv2Secret)
+    clientMock2.token = undefined
+    clientMock2.tokenLookupSelf = sinon.stub().returns(mockTokenLookupResultMustRenew)
+    clientMock2.tokenRenewSelf = sinon.stub().returns(true)
+    clientMock2.kubernetesLogin = sinon.stub().returns({
+      auth: {
+        client_token: '5678'
+      }
+    })
+
+    vaultBackend._fetchServiceAccountToken = sinon.stub().returns(jwt)
+  }
+
+  describe('_getByPath', () => {
+    beforeEach(setup)
+
+    it('proxies _get and returns entire secret', async () => {
+      const spy = sinon.spy(vaultBackend, '_get')
+
+      const secretPathValue = await vaultBackend._getByPath({
+        specOptions: {
+          vaultMountPoint: mountPoint,
+          vaultRole: role
+        },
+        path: secretKey
+      })
+
+      // First, we proxy the call to _get...
+      sinon.assert.calledWith(spy, {
+        specOptions: {
+          vaultMountPoint: mountPoint,
+          vaultRole: role
+        },
+        key: secretKey
+      })
+
+      // ... and expect to get its proper value
+      expect(secretPathValue).to.deep.equal(secretData)
+    })
+  })
+
+  describe('_get', () => {
+    beforeEach(setup)
 
     it('logs in and returns secret property value - default', async () => {
       const secretPropertyValue = await vaultBackend._get({


### PR DESCRIPTION
This pull request adds support for the `path` parameter of the existing `ExternalSecret` CRD.

Providing the path would previously throw an exception since there was no implementation of `_getByPath`.  

The following is an example using the `path` parameter.
```
apiVersion: "kubernetes-client.io/v1"
kind: ExternalSecret
metadata:
  name: hello-vault-service
spec:
  backendType: vault
  data:
    - path: secrets/data/foo # This will extract all keys from the secret foo
```

The implementation is quite simple. Since the existing `_get` method returns the entire Vault secret, serialized as JSON, we can reuse all the logic here, and simply return  back the object representation of the secret. The `kv-backend` will then pluck all keys from this object.