### PR TITLE
fix: add observedGeneration to CRD status fields

### DIFF
--- a/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
+++ b/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
@@ -188,6 +188,8 @@ spec:
                   type: string
                 status:
                   type: string
+                observedGeneration:
+                  type: number
       additionalPrinterColumns:
         - jsonPath: .status.lastSync
           name: Last Sync


### PR DESCRIPTION
updated CRD was not keeping observedGeneration in status fields causing next poll to always be scheduled in 0ms 

Fixes #746 