### PR TITLE
Ensure that the restart timer is always started

### DIFF
--- a/lib/external-secret.js
+++ b/lib/external-secret.js
@@ -76,6 +76,8 @@ async function startWatcher ({
         clearTimeout(timeout)
       })
 
+      restartTimeout()
+
       const deathEvent = await deathQueue.take()
 
       logger.info('Stopping watch stream for namespace %s due to event: %s', loggedNamespaceName, deathEvent)


### PR DESCRIPTION
Related: #763 

If there are no data events, the reset timer is never started.  If the connection to the kube api server is lost during this time and new events come in they are never seen and the stream is never restarted.

Repro: (I used minikube with ssh access)
Install helm chart
`minikube ssh`
Drop current connection from pod to api server: e.g. `conntrack -D conntrack -s 172.17.0.6 -d 10.96.0.1`
Create a new example secret (failures to connect don't matter here)
Note that the secret is not picked up nor is the server restarted. `kubectl get externalsecrets.kubernetes-client.io`

Credit and thanks to https://github.com/external-secrets/kubernetes-external-secrets/issues/362#issuecomment-719989503 for the iptables idea.

