### PR TITLE
chore(docs): add new env var for IBM Secret Manager plugin version 0.0.8 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,9 +819,12 @@ The cli option is illustrated below:
 
 ```bash
 # you need to configure ibm cloud cli with a valid endpoint 
-export IBM_CLOUD_SECRETS_MANAGER_API_URL=https://{instanceid}.{region}.secrets-manager.appdomain.cloud
-ibmcloud secrets-manager secret-create --secret-type username_password \ 
---metadata '{"collection_type": "application/vnd.ibm.secrets-manager.secret+json", "collection_total": 1}' \ 
+# If you're using plug-in version 0.0.8 or later, export the following variable.
+export SECRETS_MANAGER_URL=https://{instanceid}.{region}.secrets-manager.appdomain.cloud
+# If you're using plug-in version 0.0.6 or earlier, export the following variable.
+export IBM_CLOUD_SECRETS_MANAGER_API_URL=https://{instance_ID}.{region}.secrets-manager.appdomain.cloud
+ibmcloud secrets-manager secret-create --secret-type username_password \
+--metadata '{"collection_type": "application/vnd.ibm.secrets-manager.secret+json", "collection_total": 1}' \
 --resources '[{"name": "example-username-password-secret","description": "Extended description for my secret.","username": "user123","password": "cloudy-rainy-coffee-book"}]'
 ```
 


### PR DESCRIPTION
Export an new environment variable with your IBM Secrets Manager service endpoint URL.
refer to : https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-cli-plugin-secrets-manager-cli