### PR TITLE
fix(IBM): correctly extract secret data for IBM IAM credentials type secrets

### DIFF
--- a/lib/backends/ibmcloud-secrets-manager-backend.js
+++ b/lib/backends/ibmcloud-secrets-manager-backend.js
@@ -46,8 +46,12 @@ class IbmCloudSecretsManagerBackend extends KVBackend {
     const secret = await client.getSecret({
       secretType: secretType,
       id: key
-    })
-    return JSON.stringify(secret.result.resources[0].secret_data)
+    });
+    if (secretType === "iam_credentials") {
+      return JSON.stringify(secret.result.resources[0].api_key)
+    } else {
+      return JSON.stringify(secret.result.resources[0].secret_data)
+    }
   }
 }
 

--- a/lib/backends/ibmcloud-secrets-manager-backend.js
+++ b/lib/backends/ibmcloud-secrets-manager-backend.js
@@ -46,8 +46,8 @@ class IbmCloudSecretsManagerBackend extends KVBackend {
     const secret = await client.getSecret({
       secretType: secretType,
       id: key
-    });
-    if (secretType === "iam_credentials") {
+    })
+    if (secretType === 'iam_credentials') {
       return JSON.stringify(secret.result.resources[0].api_key)
     } else {
       return JSON.stringify(secret.result.resources[0].secret_data)


### PR DESCRIPTION
The result of IAM credentials type is difference from other types.  It does not contains a `secret_data` field. 
Below is an example:
 
```
{
  "metadata": {
    "collection_type": "application/vnd.ibm.secrets-manager.secret+json",
    "collection_total": 1
  },
  "resources": [
    {
      "access_groups": [
        "AccessGroupId-xxxxx"
      ],
      "api_key": "xxxxxx",
      "created_by": "xxx-xxxxx",
      "creation_date": "2021-07-12T04:57:49Z",
      "crn": "crn:v1:bluemix:public:secrets-manager:us-east:a/xxxx:xxxxx:secret:xxxxx",
      "id": "xxxxx",
      "labels": [
        
      ],
      "last_update_date": "2021-07-12T05:58:27Z",
      "name": "to-be-delete",
      "reuse_api_key": false,
      "secret_type": "iam_credentials",
      "service_id": "ServiceId-xxxxxx",
      "state": 1,
      "state_description": "Active",
      "ttl": 86400
    }
  ]
}
```