### PR TITLE
fix: remove AWS_DEFAULT_REGION

### DIFF
--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -5,7 +5,6 @@
 # Environment variables to set on deployment pod
 env:
   AWS_REGION: us-west-2
-  AWS_DEFAULT_REGION: us-west-2
   POLLER_INTERVAL_MILLISECONDS: 10000  # Caution, setting this frequency may incur additional charges on some platforms
   WATCH_TIMEOUT: 60000
   WATCHED_NAMESPACES: ""  # Comma separated list of namespaces, empty or unset means ALL namespaces.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -42,7 +42,6 @@ helm template e2e ../charts/kubernetes-external-secrets \
   --set env.LOCALSTACK_SM_URL=http://secretsmanager \
   --set env.AWS_ACCESS_KEY_ID=foobar \
   --set env.AWS_SECRET_ACCESS_KEY=foobar \
-  --set env.AWS_DEFAULT_REGION=us-east-1 \
   --set env.AWS_REGION=us-east-1 \
   --set env.POLLER_INTERVAL_MILLISECONDS=1000 \
   --set env.LOCALSTACK_STS_URL=http://sts | kubectl apply -f -
@@ -74,7 +73,6 @@ kubectl run \
   --env="LOCALSTACK_SM_URL=http://secretsmanager" \
   --env="AWS_ACCESS_KEY_ID=foobar" \
   --env="AWS_SECRET_ACCESS_KEY=foobar" \
-  --env="AWS_DEFAULT_REGION=us-east-1" \
   --env="AWS_REGION=us-east-1" \
   --env="LOCALSTACK_STS_URL=http://sts" \
   --generator=run-pod/v1 \

--- a/e2e/run-e2e-suite.sh
+++ b/e2e/run-e2e-suite.sh
@@ -78,7 +78,6 @@ helm install e2e ${CHART_DIR} \
   --set env.LOCALSTACK_SM_URL=http://secretsmanager \
   --set env.AWS_ACCESS_KEY_ID=foobar \
   --set env.AWS_SECRET_ACCESS_KEY=foobar \
-  --set env.AWS_DEFAULT_REGION=us-east-1 \
   --set env.AWS_REGION=us-east-1 \
   --set env.POLLER_INTERVAL_MILLISECONDS=1000 \
   --set env.LOCALSTACK_STS_URL=http://sts
@@ -108,7 +107,6 @@ kubectl run \
   --env="LOCALSTACK_SM_URL=http://secretsmanager" \
   --env="AWS_ACCESS_KEY_ID=foobar" \
   --env="AWS_SECRET_ACCESS_KEY=foobar" \
-  --env="AWS_DEFAULT_REGION=us-east-1" \
   --env="AWS_REGION=us-east-1" \
   --env="LOCALSTACK_STS_URL=http://sts" \
   --generator=run-pod/v1 \


### PR DESCRIPTION
Not sure why AWS_DEFAULT_REGION was added in the first place, but it seems misleading to have. Its not provided in the docs everywhere and the AWS SDK for JS uses `AWS_REGION` so the `AWS_DEFAULT_REGION` should not be used, if one uses the aws cli it does seem to prefer `AWS_DEFAULT_REGION` though in some cases 😄 