### PR TITLE
Fixes naming convention permission check for data items with path attribute.

### DIFF
--- a/lib/poller.js
+++ b/lib/poller.js
@@ -289,7 +289,8 @@ class Poller {
               allowed, reason
             }
           }
-        } else if (!reNaming.test(secretProperty.key)) {
+        }
+        if (!reNaming.test(secretProperty.key)) {
           allowed = false
           reason = `key name ${secretProperty.key} does not match naming convention ${namingConvention}`
           return {

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -284,7 +284,7 @@ class Poller {
         if (secretProperty.path) {
           if (!reNaming.test(secretProperty.path)) {
             allowed = false
-            reason = `path name ${secretProperty.path} does not match naming convention ${namingConvention}`
+            reason = `path ${secretProperty.path} does not match naming convention ${namingConvention}`
             return {
               allowed, reason
             }

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -281,7 +281,15 @@ class Poller {
     // Testing data property
     if (namingConvention && externalData) {
       externalData.forEach((secretProperty, index) => {
-        if (!reNaming.test(secretProperty.key)) {
+        if (secretProperty.path) {
+          if (!reNaming.test(secretProperty.path)) {
+            allowed = false
+            reason = `path name ${secretProperty.path} does not match naming convention ${namingConvention}`
+            return {
+              allowed, reason
+            }
+          }
+        } else if (!reNaming.test(secretProperty.key)) {
           allowed = false
           reason = `key name ${secretProperty.key} does not match naming convention ${namingConvention}`
           return {

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -983,6 +983,26 @@ describe('Poller', () => {
           permitted: false
         },
         {
+          // test regex on path
+          ns: { metadata: { annotations: { [namingPermittedAnnotation]: 'dev/team-a/.*' } } },
+          descriptor: {
+            data: [
+              { path: 'dev/team-b/secret' }
+            ]
+          },
+          permitted: false
+        },
+        {
+          // test regex on path when key is also specified
+          ns: { metadata: { annotations: { [namingPermittedAnnotation]: 'dev/team-a/.*' } } },
+          descriptor: {
+            data: [
+              { path: 'dev/team-b/secret', key: 'dev/team-a/secret' }
+            ]
+          },
+          permitted: false
+        },
+        {
           // test regex
           ns: { metadata: { annotations: { [namingPermittedAnnotation]: 'dev/team-a/.*' } } },
           descriptor: {


### PR DESCRIPTION
The permission checking code is currently ignoring the `path` attributes when evaluating. This results in permission checks for secrets defined like this:
```
apiVersion: kubernetes-client.io/v1
kind: ExternalSecret
metadata:
  name: test
spec:
  backendType: systemManager
  data:
  - path: dev/team-a/secret
```
with the error message `ERROR, not allowed to fetch secret: test/test: key name undefined does not match naming convention ^dev/team-a/.*`.
This PR adds handling of the `path` attribute in the permissions check.