### PR TITLE
Add optional deployment labels value to charts

### DIFF
--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -79,6 +79,7 @@ The following table lists the configurable parameters of the `kubernetes-externa
 | `serviceAccount.create`                   | Whether a new service account name should be created.                                                                             | `true`                                |
 | `serviceAccount.name`                     | Service account to be used.                                                                                                       | automatically generated               |
 | `serviceAccount.annotations`              | Annotations to be added to service account                                                                                        | `nil`                                 |
+| `deploymentLabels`                        | Additional labels to be added the deployment                                                                                      | `{}`                                  |
 | `podAnnotations`                          | Annotations to be added to pods                                                                                                   | `{}`                                  |
 | `podLabels`                               | Additional labels to be added to pods                                                                                             | `{}`                                  |
 | `priorityClassName`                       | Priority class to be assigned to pods

--- a/charts/kubernetes-external-secrets/templates/deployment.yaml
+++ b/charts/kubernetes-external-secrets/templates/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     helm.sh/chart: {{ include "kubernetes-external-secrets.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.deploymentLabels }}
+      {{- toYaml .Values.deploymentLabels | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -134,6 +134,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# All label values must be strings
+deploymentLabels: {}
+
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
Have a use case where we want to add labels to the deployments, but were currently unable to do so with the charts.  Adding this optional value