### PR TITLE
Fixes naming convention permission check for data items with path attribute only.

### DIFF
--- a/lib/poller.js
+++ b/lib/poller.js
@@ -289,8 +289,7 @@ class Poller {
               allowed, reason
             }
           }
-        }
-        if (!reNaming.test(secretProperty.key)) {
+        } else if (!reNaming.test(secretProperty.key)) {
           allowed = false
           reason = `key name ${secretProperty.key} does not match naming convention ${namingConvention}`
           return {

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -281,15 +281,15 @@ class Poller {
     // Testing data property
     if (namingConvention && externalData) {
       externalData.forEach((secretProperty, index) => {
-        if (secretProperty.path) {
-          if (!reNaming.test(secretProperty.path)) {
-            allowed = false
-            reason = `path ${secretProperty.path} does not match naming convention ${namingConvention}`
-            return {
-              allowed, reason
-            }
+        if ('path' in secretProperty && !reNaming.test(secretProperty.path)) {
+          allowed = false
+          reason = `path ${secretProperty.path} does not match naming convention ${namingConvention}`
+          return {
+            allowed, reason
           }
-        } else if (!reNaming.test(secretProperty.key)) {
+        }
+
+        if ('key' in secretProperty && !reNaming.test(secretProperty.key)) {
           allowed = false
           reason = `key name ${secretProperty.key} does not match naming convention ${namingConvention}`
           return {

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -987,6 +987,16 @@ describe('Poller', () => {
           ns: { metadata: { annotations: { [namingPermittedAnnotation]: 'dev/team-a/.*' } } },
           descriptor: {
             data: [
+              { path: 'dev/team-a/secret' }
+            ]
+          },
+          permitted: true
+        },
+        {
+          // test regex on path
+          ns: { metadata: { annotations: { [namingPermittedAnnotation]: 'dev/team-a/.*' } } },
+          descriptor: {
+            data: [
               { path: 'dev/team-b/secret' }
             ]
           },

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -993,6 +993,33 @@ describe('Poller', () => {
           permitted: true
         },
         {
+          ns: { metadata: { annotations: { [namingPermittedAnnotation]: 'dev/team-a/.*' } } },
+          descriptor: {
+            data: [
+              { key: 'dev/team-a/secret', name: 'somethingelse', path: '' }
+            ]
+          },
+          permitted: false
+        },
+        {
+          ns: { metadata: { annotations: { [namingPermittedAnnotation]: 'dev/team-a/.*' } } },
+          descriptor: {
+            data: [
+              { key: 'this-should-fail', name: 'somethingelse', path: 'dev/team-a/such-path' }
+            ]
+          },
+          permitted: false
+        },
+        {
+          ns: { metadata: { annotations: { [namingPermittedAnnotation]: 'dev/team-a/.*' } } },
+          descriptor: {
+            data: [
+              { key: 'dev/team-a/such-key', name: 'somethingelse', path: 'this-should-fail' }
+            ]
+          },
+          permitted: false
+        },
+        {
           // test regex on path
           ns: { metadata: { annotations: { [namingPermittedAnnotation]: 'dev/team-a/.*' } } },
           descriptor: {


### PR DESCRIPTION
This change fixes the false positive in the permission checking code when the `path` attribute is used. Without the fix, the added test fails, as the as the code always tries to check the `key` attribute, even when only `path` is provided. It ends up coercing the `undefined` value to a sting and testing that.