### PR TITLE
fix: update image to use alpine 3.14 base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:14-alpine3.14
 
 ENV NODE_ENV production
 ENV NPM_CONFIG_LOGLEVEL warn

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:14-alpine3.14
 
 # Setup source directory
 RUN mkdir /app


### PR DESCRIPTION
Current image is based on alpine which is alpine 3.11, which is end of life in november.
Update to specify specific alpine version (3.14) base

Fixes #842 