### PR TITLE
feat: add runtime metrics

### DIFF
--- a/bin/daemon.js
+++ b/bin/daemon.js
@@ -56,6 +56,7 @@ async function main () {
   })
 
   const registry = Prometheus.register
+  Prometheus.collectDefaultMetrics({ register: registry })
   const metrics = new Metrics({ registry })
 
   const pollerFactory = new PollerFactory({


### PR DESCRIPTION
Small enhancement for #826: export default `nodejs_*` metrics. They can be displayed with the [nodejs app dashboard](https://grafana.com/grafana/dashboards/11159).