### PR TITLE
Fix isBinary when using dataFromWithOptions

### DIFF
--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -121,10 +121,38 @@ class KVBackend extends AbstractBackend {
   _fetchDataFromValuesWithOptions ({ dataFromWithOptions, specOptions }) {
     return Promise.all(dataFromWithOptions.map(async dataItem => {
       const { key, ...keyOptions } = dataItem
-      const value = await this._get({ key, specOptions, keyOptions })
+      let data = await this._get({ key, keyOptions, specOptions })
+      const response = {}
 
       try {
-        return JSON.parse(value)
+        data = JSON.parse(data)
+      } catch (err) {
+        this._logger.warn(`Failed to JSON.parse value for '${key}',` +
+          ' please verify that your secret value is correctly formatted as JSON.')
+        return
+      }
+
+      const isBinary = 'isBinary' in dataItem && dataItem.isBinary === true
+
+      for (const key in data) {
+        response[key] = data[key]
+      }
+
+      if (isBinary) {
+        for (const key in data) {
+          // value in the backend is binary data which is already encoded in base64.
+          if (typeof data[key] === 'string') {
+            // Skip this step if the value from the backend is not a string (e.g., AWS
+            // SecretsManager will already return a `Buffer` with base64 encoding if the
+            // secret contains `SecretBinary` instead of `SecretString`).
+            response[key] = Buffer.from(data[key], 'base64')
+            console.log(response[key])
+          }
+        }
+      }
+
+      try {
+        return response
       } catch (err) {
         this._logger.warn(`Failed to JSON.parse value for '${dataItem}',` +
           ' please verify that your secret value is correctly formatted as JSON.')

--- a/lib/backends/kv-backend.test.js
+++ b/lib/backends/kv-backend.test.js
@@ -272,14 +272,22 @@ describe('kv-backend', () => {
       kvBackend._get = sinon.stub()
     })
     it('handles secrets with spec and key options', async () => {
-      kvBackend._get.onFirstCall().resolves('{"fakePropertyName1":"fakePropertyValue1"}')
-      kvBackend._get.onSecondCall().resolves('{"fakePropertyName2":"fakePropertyValue2"}')
+      kvBackend._get.onCall(0).resolves('{"fakePropertyName1":"fakePropertyValue1"}')
+      kvBackend._get.onCall(1).resolves('{"fakePropertyName2":"fakePropertyValue2"}')
+      kvBackend._get.onCall(2).resolves('{"fakePropertyName3":"YmluYXJ5Cg=="}')
       const dataFromValuesWithOptions = await kvBackend._fetchDataFromValuesWithOptions({
-        dataFromWithOptions: [{ versionStage: 'AWSCURRENT', key: 'fakeKey1' },
-          { versionId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', key: 'fakeKey2' }],
+        dataFromWithOptions: [
+          { versionStage: 'AWSCURRENT', key: 'fakeKey1' },
+          { versionId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', key: 'fakeKey2' },
+          { isBinary: true, key: 'fakeKey3' }
+        ],
         specOptions: { passMeAlong: true }
       })
-      expect(dataFromValuesWithOptions).to.deep.equal([{ fakePropertyName1: 'fakePropertyValue1' }, { fakePropertyName2: 'fakePropertyValue2' }])
+      expect(dataFromValuesWithOptions).to.deep.equal([
+        { fakePropertyName1: 'fakePropertyValue1' },
+        { fakePropertyName2: 'fakePropertyValue2' },
+        { fakePropertyName3: Buffer.from('YmluYXJ5Cg==', 'base64') }
+      ])
       expect(kvBackend._get.getCall(0).args[0]).to.deep.equal({
         key: 'fakeKey1',
         keyOptions: {
@@ -291,6 +299,13 @@ describe('kv-backend', () => {
         key: 'fakeKey2',
         keyOptions: {
           versionId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+        },
+        specOptions: { passMeAlong: true }
+      })
+      expect(kvBackend._get.getCall(2).args[0]).to.deep.equal({
+        key: 'fakeKey3',
+        keyOptions: {
+          isBinary: true
         },
         specOptions: { passMeAlong: true }
       })

--- a/lib/backends/kv-backend.test.js
+++ b/lib/backends/kv-backend.test.js
@@ -275,18 +275,21 @@ describe('kv-backend', () => {
       kvBackend._get.onCall(0).resolves('{"fakePropertyName1":"fakePropertyValue1"}')
       kvBackend._get.onCall(1).resolves('{"fakePropertyName2":"fakePropertyValue2"}')
       kvBackend._get.onCall(2).resolves('{"fakePropertyName3":"YmluYXJ5Cg=="}')
+      kvBackend._get.onCall(3).resolves('{"fakePropertyName4":"YmluYXJ5MQ==","fakePropertyName5":"YmluYXJ5Mg=="}')
       const dataFromValuesWithOptions = await kvBackend._fetchDataFromValuesWithOptions({
         dataFromWithOptions: [
           { versionStage: 'AWSCURRENT', key: 'fakeKey1' },
           { versionId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', key: 'fakeKey2' },
-          { isBinary: true, key: 'fakeKey3' }
+          { isBinary: true, key: 'fakeKey3' },
+          { isBinary: true, key: 'fakeKey4' }
         ],
         specOptions: { passMeAlong: true }
       })
       expect(dataFromValuesWithOptions).to.deep.equal([
         { fakePropertyName1: 'fakePropertyValue1' },
         { fakePropertyName2: 'fakePropertyValue2' },
-        { fakePropertyName3: Buffer.from('YmluYXJ5Cg==', 'base64') }
+        { fakePropertyName3: Buffer.from('YmluYXJ5Cg==', 'base64') },
+        { fakePropertyName4: Buffer.from('YmluYXJ5MQ==', 'base64'), fakePropertyName5: Buffer.from('YmluYXJ5Mg==', 'base64') }
       ])
       expect(kvBackend._get.getCall(0).args[0]).to.deep.equal({
         key: 'fakeKey1',
@@ -304,6 +307,13 @@ describe('kv-backend', () => {
       })
       expect(kvBackend._get.getCall(2).args[0]).to.deep.equal({
         key: 'fakeKey3',
+        keyOptions: {
+          isBinary: true
+        },
+        specOptions: { passMeAlong: true }
+      })
+      expect(kvBackend._get.getCall(3).args[0]).to.deep.equal({
+        key: 'fakeKey4',
         keyOptions: {
           isBinary: true
         },


### PR DESCRIPTION
isBinary did not do anything when used in dataFromWithOptions.  This will enable the use of isBinary in dataFromWithOptions.

Fixes https://github.com/external-secrets/kubernetes-external-secrets/issues/883