### PR TITLE
Expand SSM Parameter Store docs to clarify use of version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ spec:
       recursive: false
 ```
 
-`data` and `dataFrom` retrieve the latest version of the parameter by default, if you want to get values for a specific version you can use append the version number to the key:
+`data` and `dataFrom` retrieve the latest version of the parameter by default. If you want to get values for a specific version, you can append the version number to the key:
 
 ```yml
 apiVersion: kubernetes-client.io/v1

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ spec:
 
 You can scrape values from SSM Parameter Store individually or by providing a path to fetch all keys inside.
 
-When fetching all keys by path, you can also scrape all sub paths (child paths) if you need to. The default is not to scrape child paths.
+When fetching all keys by path, you can also recursively scrape all the sub paths (child paths) if you need to. The default is not to scrape child paths.
 
 ```yml
 apiVersion: kubernetes-client.io/v1

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ spec:
 
 You can scrape values from SSM Parameter Store individually or by providing a path to fetch all keys inside.
 
-Additionally you can also scrape all sub paths (child paths) if you need to. The default is not to scrape child paths
+When fetching all keys by path, you can also scrape all sub paths (child paths) if you need to. The default is not to scrape child paths.
 
 ```yml
 apiVersion: kubernetes-client.io/v1
@@ -580,6 +580,27 @@ spec:
     - path: /extra-people/
       recursive: false
 ```
+
+`data` and `dataFrom` retrieve the latest version of the parameter by default, if you want to get values for a specific version you can use append the version number to the key:
+
+```yml
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: hello-service
+spec:
+  backendType: systemManager
+  # optional: specify role to assume when retrieving the data
+  roleArn: arn:aws:iam::123456789012:role/test-role
+  # optional: specify region
+  region: us-east-1
+  dataFrom:
+    - hello-service/credentials:3
+  data:
+    - key: /foo/name
+      name: fooName:5
+```
+
 ### Akeyless Vault
 
 kubernetes-external-secrets supports fetching secrets from [Akeyless Vault](https://www.akeyless.io/), .


### PR DESCRIPTION
Expands on the AWS SSM Parameter Store docs with examples of how to fetch a specific version of a given parameter.

Whilst this is not technically a feature offered by the package directly and instead supported by the underlying AWS SDK, it's a very useful feature worth highlighting which allows immutable, versioned controlled references to SSM instead of always fetching the latest value that can change.