### PR TITLE
chore(docs): Extension of the IBM Secrets Manager example

### DIFF
--- a/examples/ibmcloud-secrets-manager.yaml
+++ b/examples/ibmcloud-secrets-manager.yaml
@@ -1,3 +1,4 @@
+# Secret Manager secret type: username_password, arbitrary, kev, or iam_credentials
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
@@ -7,7 +8,45 @@ spec:
   # optional: true to key secrets by name instead of by ID
   keyByName: true
   data:
+    # get username and password as json of secret type: username_password
     - key: my-creds
       name: username_password
-      # Secret Manager secret type: username_password, arbitrary, or iam_credentials
       secretType: username_password
+    # get just the password of secret type: username_password
+    - key: my-creds
+      name: username
+      property: password
+      secretType: username_password
+    # get just the value of a specific key of secret type: keyvalue
+    - key: my-creds
+      name: key
+      property: payload.key
+      secretType: kv
+    # get value of secret type: arbitrary
+    - key: my-creds
+      name: test
+      property: payload
+      secretType: arbitrary
+---
+# Secret Manager secret type: imported_cert
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: ibmcloud-secrets-manager
+spec:
+  backendType: ibmcloudSecretsManager
+  template:
+    type: kubernetes.io/tls
+  # optional: true to key secrets by name instead of by ID
+  keyByName: true
+  data:
+    # get certificate secret type: imported_cert
+    - key: my-creds
+      name: tls.crt
+      property: certificate
+      secretType: imported_cert
+    # get private key from secret type: imported_cert
+    - key: my-creds
+      name: tls.key
+      property: private_key
+      secretType: imported_cert


### PR DESCRIPTION
Currently, the the IBM Cloud Secrets Manager example is very minimalistic. The example also states that only secrets of type username_password, arbitrary, or iam_credentials can be retrieved. Recently, all secret types can be retrieved (including certificates).