### PR TITLE
fix(deps): bump node-forge CVE-2022-24772 CVE-2022-24771 CVE-2022-0122

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5627,9 +5627,9 @@
       }
     },
     "node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
+      "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA=="
     },
     "node-preload": {
       "version": "0.2.1",


### PR DESCRIPTION
Signed-off-by: Markus Maga <markus@maga.se>